### PR TITLE
Faster sum(BroadcastArray)

### DIFF
--- a/src/lazybroadcasting.jl
+++ b/src/lazybroadcasting.jl
@@ -37,6 +37,10 @@ getindex(B::BroadcastArray{<:Any,1}, kr::AbstractVector{<:Integer}) =
 
 copy(bc::Broadcasted{<:LazyArrayStyle}) = BroadcastArray(bc)
 
+# issue 16: sum(b, dims=(1,2,3)) faster than sum(b)
+Base._sum(b::BroadcastArray{T,N}, ::Colon) where {T,N} = first(Base._sum(b, ntuple(identity, N)))
+Base._prod(b::BroadcastArray{T,N}, ::Colon) where {T,N} = first(Base._prod(b, ntuple(identity, N)))
+
 BroadcastStyle(::Type{<:BroadcastArray{<:Any,N}}) where N = LazyArrayStyle{N}()
 BroadcastStyle(L::LazyArrayStyle{N}, ::StaticArrayStyle{N}) where N = L
 BroadcastStyle(::StaticArrayStyle{N}, L::LazyArrayStyle{N})  where N = L

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -171,6 +171,9 @@ end
     @test C == A .+ 2
     D = BroadcastArray(+, A, C)
     @test D == A + C
+    
+    @test sum(B) ≈ sum(exp, A)
+    @test sum(C) ≈ sum(A .+ 2)
 
     x = Vcat([3,4], [1,1,1,1,1], 1:3)
     @test x .+ (1:10) isa Vcat


### PR DESCRIPTION
This simply makes the complete sum of a BroadcastArray call `sum(A,dims=1:N)` as this seems to be faster. For example, without this PR: 

```julia
julia> using LazyArrays, BenchmarkTools

julia> A = rand(100,100); B = rand(100); C = rand(100);

julia> @btime sum($A .* $B .* $C')
  5.316 μs (2 allocations: 78.20 KiB)
1220.0468263958778

julia> @btime sum(BroadcastArray(*, $A, $B, $C'))
  26.259 μs (11 allocations: 256 bytes)
1220.046826395877

julia> @btime sum(BroadcastArray(*, $A, $B, $C'), dims=(1,2))
  3.062 μs (12 allocations: 416 bytes)
1×1 Array{Float64,2}:
 1220.0468263958776
```

Another example in #16. That issue also has a puzzle about `B'` vs `reshape(B,1,:)` which this does nothing about. 