### PR TITLE
More Revise-friendly "README injection"

### DIFF
--- a/src/LazyArrays.jl
+++ b/src/LazyArrays.jl
@@ -1,5 +1,8 @@
-@doc read(joinpath(dirname(@__DIR__), "README.md"), String) ->
 module LazyArrays
+
+# Use README as the docstring of the module:
+@doc read(joinpath(dirname(@__DIR__), "README.md"), String) LazyArrays
+
 using Base, Base.Broadcast, LinearAlgebra, FillArrays, StaticArrays
 import LinearAlgebra.BLAS
 


### PR DESCRIPTION
I realized the "hack" I added in #34 to inject README as the docstring of the module was not working well with Revise.  It replaces `LazyArrays` with `Main.LazyArrays` when you edit `src/LazyArrays.jl`.  This PR implements a better version that avoids it.
