### PR TITLE
Call instantiate on Applied in @~ macro

### DIFF
--- a/src/lazyapplying.jl
+++ b/src/lazyapplying.jl
@@ -18,9 +18,9 @@ Applied{Style}(f::F, args::Args) where {Style,F,Args<:Tuple} =
 
 check_applied_axes(A::Applied) = nothing
 
-function instantiate(A::Applied) 
+function instantiate(A::Applied{Style}) where Style
     check_applied_axes(A)
-    A
+    Applied{Style}(A.f, map(instantiate, A.args))
 end
 
 _typesof() = ()

--- a/src/lazymacro.jl
+++ b/src/lazymacro.jl
@@ -34,7 +34,7 @@ end
 
 function bc_expr(ex::Expr)
     @assert is_dotcall(ex)
-    return :($(Broadcast.instantiate)($lazy.($(bc_expr_impl(ex)))))
+    return :($lazy.($(bc_expr_impl(ex))))
 end
 
 bc_expr_impl(x) = x
@@ -51,7 +51,6 @@ end
 
 function app_expr(ex::Expr)
     @assert is_call(ex)
-    # instantiate?
     return app_expr_impl(ex)
 end
 
@@ -99,5 +98,5 @@ julia> @~ A * B + C
 macro ~(ex)
     checkex(ex)
     # Expanding macro here to support, e.g., `@.`
-    esc(lazy_expr(macroexpand(__module__, ex)))
+    esc(:($instantiate($(lazy_expr(macroexpand(__module__, ex))))))
 end

--- a/src/linalg/mul.jl
+++ b/src/linalg/mul.jl
@@ -6,8 +6,12 @@ const Mul{Style, Factors<:Tuple} = Applied{Style, typeof(*), Factors}
 Mul(A...) = applied(*, A...)
 
 check_mul_axes(A) = nothing
+_check_mul_axes(::Number, ::Number) = nothing
+_check_mul_axes(::Number, _) = nothing
+_check_mul_axes(_, ::Number) = nothing
+_check_mul_axes(A, B) = axes(A,2) == axes(B,1) || throw(DimensionMismatch("Second axis of A, $(axes(A,2)), and first axis of B, $(axes(B,1)) must match"))
 function check_mul_axes(A, B, C...) 
-    axes(A,2) == axes(B,1) || throw(DimensionMismatch("Second axis of A, $(axes(A,2)), and first axis of B, $(axes(B,1)) must match"))
+    _check_mul_axes(A, B)
     check_mul_axes(B, C...)
 end
 


### PR DESCRIPTION
This is a PR against #46.

Now that we have `instantiate(::Applied) `, I think the best strategy to call it in `@~` is to do this in the "root" node and let it propagate through recursion.