### PR TITLE
RFC/WIP: Lower AST using an external package (GroundEffects.jl)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.12.1"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+GroundEffects = "d00d4687-65cd-4fba-8fd9-ecb45a036ebe"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"


### PR DESCRIPTION
The idea of this PR is to factor out the common logic of lowering AST to an external package: https://github.com/tkf/GroundEffects.jl (still not registered yet)

As I hinted at https://github.com/JuliaArrays/LazyArrays.jl/issues/43#issuecomment-525519510, this would handle something like `@~ [A B; C D]`.  I'm still trying to see if this approach is beneficial by using GroundEffects.jl in different packages.

ref: https://github.com/tkf/GroundEffects.jl/issues/1