### PR TITLE
Fix `@~ a.b`; more robust `is_call` and `is_dotcall`

### DIFF
--- a/src/lazymacro.jl
+++ b/src/lazymacro.jl
@@ -13,12 +13,11 @@ Broadcast.broadcasted(::typeof(lazy), x) = LazyCast(x)
 Broadcast.materialize(x::LazyCast) = x.value
 
 
-is_call(ex::Expr) =
-    ex.head == :call && !startswith(String(ex.args[1]), ".")
+is_call(ex) = isexpr(ex, :call) && !is_dotcall(ex)
 
-is_dotcall(ex::Expr) =
-    (ex.head == :. && ex.args[2].head === :tuple) ||
-    (ex.head == :call && startswith(String(ex.args[1]), "."))
+is_dotcall(ex) =
+    (isexpr(ex, :.) && isexpr(ex.args[2], :tuple)) ||
+    (isexpr(ex, :call) && ex.args[1] isa Symbol && startswith(String(ex.args[1]), "."))
 # e.g., `f.(x, y, z)` or `x .+ y .+ z`
 
 lazy_expr(x) = x

--- a/test/macrotests.jl
+++ b/test/macrotests.jl
@@ -62,6 +62,29 @@ testparams = [
     end
 end
 
+struct CustomProperty end
+Base.getproperty(::CustomProperty, property::Symbol) = property
+Base.getproperty(::CustomProperty, property) = property
+
+complex_number = 1 + 2im
+custom_property = CustomProperty()
+
+expressions_block = quote
+    complex_number.im # https://github.com/JuliaArrays/LazyArrays.jl/pull/69
+    custom_property."property"
+end
+testparams = [
+    ("$(rmlines(ex))", ex) for ex in expressions_block.args if ex isa Expr
+]
+
+@testset "@~ non-lazy" begin
+    @testset "$label" for (label, ex) in testparams
+        desired = @eval $ex
+        actual = @eval @~ $ex
+        @test actual === desired
+    end
+end
+
 @testset "@~ laziness" begin
     A = ones(1, 1)
     x = [1]


### PR DESCRIPTION
fix #66