### PR TITLE
Allow use with StaticArrays 0.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 FillArrays = "0.7,0.8"
 MacroTools = "0.4.5,0.5"
-StaticArrays = "0.8,0.9,0.10,0.11"
+StaticArrays = "0.8,0.9,0.10,0.11,0.12"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
Tests seem to pass locally for this; API deprecations were very minor (semver seems to be a blunt weapon for dealing with "technically breaking" but not actually very breaking changes...)

XRef https://discourse.julialang.org/t/staticarrays-0-12-0-new-static-array-literal-syntax/30645/3