### PR TITLE
Fix for copy #85

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LazyArrays"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "0.14.9"
+version = "0.14.10"
 
 
 [deps]

--- a/src/lazyapplying.jl
+++ b/src/lazyapplying.jl
@@ -184,7 +184,7 @@ AbstractArray{T,N}(A::ApplyArray{<:Any,N}) where {T,N} = ApplyArray{T,N}(A.f, ma
 
 @inline axes(A::ApplyArray) = axes(Applied(A))
 @inline size(A::ApplyArray) = map(length, axes(A))
-@inline copy(A::ApplyArray) = ApplyArray(A.f, map(copy,A.args)...)
+@inline copy(A::ApplyArray{T,N}) where {T,N} = ApplyArray{T,N}(A.f, map(copy,A.args)...)
 
 
 struct LazyArrayApplyStyle <: AbstractArrayApplyStyle end

--- a/test/applytests.jl
+++ b/test/applytests.jl
@@ -40,3 +40,12 @@ end
     @test M isa ApplyArray
     @test M == exp(A)
 end
+
+@testset "copy (#85)" begin
+    Base.size(A::Applied) = (length(A.args[1]),)
+    Base.eltype(A::Applied)  = eltype(A.args[1])
+    v = ApplyVector(vec, ones(Int, 2, 2))
+    vc = copy(float.(v))
+    ve = convert(Vector, vc)
+    @test eltype(ve) == Float64
+end


### PR DESCRIPTION
I'm not familiar with the code, please let me know if it should be changed elsewhere for instance in 

```julia
copy(A::Applied{LazyArrayApplyStyle}) = ApplyArray(A)
```

cheers

closes #85 