### PR TITLE
Use $ to eagerly evaluate expressions in @~

### DIFF
--- a/src/lazymacro.jl
+++ b/src/lazymacro.jl
@@ -64,6 +64,10 @@ app_expr_impl(x) = x
 function app_expr_impl(ex::Expr)
     # walk down chain of calls and lazy-ify them
     if is_call(ex)
+        if isexpr(ex.args[1], :$)
+            # eagerly evaluate the call
+            return Expr(:call, ex.args[1].args[1], ex.args[2:end]...)
+        end
         return :($applied($(app_expr_impl.(ex.args)...)))
     else
         return lazy_expr(ex)

--- a/test/macrotests.jl
+++ b/test/macrotests.jl
@@ -97,4 +97,23 @@ end
     @test bc.args[1].args isa Tuple{Applied, Int}
 end
 
+@testset "@~ and \$" begin
+    A = ones(1, 1)
+    x = [1]
+
+    # Use `$` to evaluate a sub-expression eagerly
+    bc = @~ A .+ $Ref(x)
+    @test bc isa Broadcasted
+    @test bc.args[1] === A
+    @test bc.args[2] isa Ref  # not Applied
+    @test bc.args[2][] === x
+
+    # Use `$$` when combined with `@.`
+    bc = @~ @. A + $$Ref(x)
+    @test bc isa Broadcasted
+    @test bc.args[1] === A
+    @test bc.args[2] isa Ref  # not Applied
+    @test bc.args[2][] === x
+end
+
 end  # module


### PR DESCRIPTION
With this PR, you can use `@~ A .+ $Ref(x)` to eagerly evaluate the sub-expression `Ref(x)`.