### PR TITLE
copy method for BroadcastArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,8 @@ StaticArrays = "0.11, 0.12"
 julia = "1"
 
 [extras]
+Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Tracker", "Test"]

--- a/src/lazybroadcasting.jl
+++ b/src/lazybroadcasting.jl
@@ -213,3 +213,11 @@ call(b::BroadcastLayout, a::AdjOrTrans) = call(b, parent(a))
 transposelayout(b::BroadcastLayout) = b
 arguments(b::BroadcastLayout, A::Adjoint) = map(adjoint, arguments(b, parent(A)))
 arguments(b::BroadcastLayout, A::Transpose) = map(transpose, arguments(b, parent(A)))
+
+##
+# copy
+##
+
+_broadcasted(b::BroadcastArray) = broadcasted(b.f, _broadcasted.(b.args)...)
+_broadcasted(b) = b
+Base.copy(b::BroadcastArray) = materialize(_broadcasted(b))

--- a/test/broadcasttests.jl
+++ b/test/broadcasttests.jl
@@ -1,4 +1,4 @@
-using LazyArrays, ArrayLayouts, LinearAlgebra, FillArrays, StaticArrays, Test
+using LazyArrays, ArrayLayouts, LinearAlgebra, FillArrays, StaticArrays, Tracker, Test
 import LazyArrays: BroadcastLayout, arguments, LazyArrayStyle
 import Base: broadcasted
 
@@ -149,5 +149,10 @@ import Base: broadcasted
         @test arguments(Vc) == (B.args[1][1:3,1:2]', permutedims(B.args[2][1:3]))
         @test arguments(Vt) == (transpose(B.args[1][1:3,1:2]), permutedims(B.args[2][1:3]))
         @test BroadcastArray(Vc) == BroadcastArray(Vt) == Vc == (Array(B)')[1:2,1:3]      
+    end
+
+    @testset "copy to TrackedArray" begin
+        a = LazyArray(broadcasted(+, param(rand(3, 3)), 1))
+        @test copy(a) isa TrackedArray
     end
 end

--- a/test/broadcasttests.jl
+++ b/test/broadcasttests.jl
@@ -153,6 +153,6 @@ import Base: broadcasted
 
     @testset "copy to TrackedArray" begin
         a = LazyArray(broadcasted(+, param(rand(3, 3)), 1))
-        @test copy(a) isa TrackedArray
+        @test @inferred(copy(a)) isa TrackedArray
     end
 end


### PR DESCRIPTION
This PR adds a `copy` method for `BroadcastArray`. This is useful when doing AD. For example, the following code now returns a `TrackedArray` in `Tracker` when before it would return an array of `TrackedReal`s.

```julia
julia> using LazyArrays, Tracker

julia> a = BroadcastArray(+, param(rand(3, 3)), rand(3))
3×3 BroadcastArray{Tracker.TrackedReal{Float64},2,typeof(+),Tuple{TrackedArray{…,Array{Float64,2}},Array{Float64,1}}}:
 0.975444  1.35531  0.908767
 1.02567   1.21207  0.584532
 0.91811   1.01353  1.13322

julia> copy(a)
Tracked 3×3 Array{Float64,2}:
 0.975444  1.35531  0.908767
 1.02567   1.21207  0.584532
 0.91811   1.01353  1.13322
```