### PR TITLE
Recursive indexing of concatenated arrays

### DIFF
--- a/src/lazyconcat.jl
+++ b/src/lazyconcat.jl
@@ -82,7 +82,7 @@ map(::typeof(copy), f::Vcat) = Vcat(map.(copy, f.args)...)
     vcat_setindex_recursive!(f, v, idx, f.args...)
 
 @propagate_inbounds @inline function vcat_setindex_recursive!(
-        f, v, idx::NTuple{1}, A, args...)
+        f::Vcat{T,1} where T, v, idx::NTuple{1}, A, args...)
     k, = idx
     n = length(A)
     k ≤ n && return setindex!(A, v, idx...)
@@ -90,7 +90,7 @@ map(::typeof(copy), f::Vcat) = Vcat(map.(copy, f.args)...)
 end
 
 @propagate_inbounds @inline function vcat_setindex_recursive!(
-        f, v, idx::NTuple{2}, A, args...)
+        f::Vcat{T,2} where T, v, idx::NTuple{2}, A, args...)
     k, j = idx
     n = size(A, 1)
     k ≤ n && return setindex!(A, v, idx...)

--- a/src/lazyconcat.jl
+++ b/src/lazyconcat.jl
@@ -92,7 +92,7 @@ end
 @propagate_inbounds @inline function vcat_setindex_recursive!(
         f, v, idx::NTuple{2}, A, args...)
     k, j = idx
-    n = length(A)
+    n = size(A, 1)
     k ≤ n && return setindex!(A, v, idx...)
     vcat_setindex_recursive!(f, v, (k - n, j), args...)
 end

--- a/src/lazyconcat.jl
+++ b/src/lazyconcat.jl
@@ -78,9 +78,6 @@ getindex(f::Applied{<:Any,typeof(vcat)}, k::Integer, j::Integer)= vcat_getindex(
 copy(f::Vcat) = Vcat(map(copy, f.args)...)
 map(::typeof(copy), f::Vcat) = Vcat(map.(copy, f.args)...)
 
-@propagate_inbounds @inline vcat_setindex!(f, v, idx::Vararg{Integer}) =
-    vcat_setindex_recursive!(f, v, idx, f.args...)
-
 @propagate_inbounds @inline function vcat_setindex_recursive!(
         f::Vcat{T,1} where T, v, idx::NTuple{1}, A, args...)
     k, = idx


### PR DESCRIPTION
This is an attempt to fix the performance issues discussed in #132. These are type instability issues when indexing heterogeneous concatenated arrays with `getindex` and `setindex!`.

In this PR, `getindex` and `setindex!` are reimplemented for the `Vcat{1}`, `Vcat{2}` and `Hcat` lazy concatenation types.

Here is a small benchmark for comparison, on Julia 1.5.1:

```julia
using BenchmarkTools
using LazyArrays
using StaticArrays

A = Vcat(
    rand(1:10, 12),
    @SVector(zeros(Int, 4)),
    4:42,
)

N = length(A)
```

On LazyArrays master:
```julia
@btime $A[1];   # 7.356 ns (0 allocations: 0 bytes)
@btime $A[14];  # 43.875 ns (2 allocations: 112 bytes)
@btime $A[$N];  # 80.788 ns (4 allocations: 208 bytes)
```

With this PR:
```julia
@btime $A[1];   # 4.329 ns (0 allocations: 0 bytes)
@btime $A[14];  # 4.668 ns (0 allocations: 0 bytes)
@btime $A[$N];  # 6.105 ns (0 allocations: 0 bytes)
```