### PR TITLE
Fix dotcall detection in @~ macro expansion and add some eager functions

### DIFF
--- a/src/lazyapplying.jl
+++ b/src/lazyapplying.jl
@@ -305,7 +305,7 @@ applybroadcaststyle(::Type{<:AbstractArray{<:Any,N}}, ::LazyLayout) where N = La
 BroadcastStyle(M::Type{<:ApplyArray}) = applybroadcaststyle(M, MemoryLayout(M))
 
 ### 
-# Number special cases
+# Eager applications
 ###
 
 for op in (:+, :-, :*, :\)
@@ -314,6 +314,10 @@ end
 
 for op in (:one, :zero)
     @eval applied(::typeof($op), ::Type{T}) where T = $op(T)
+end
+
+for f in (view, Base.maybeview, (:))
+    @eval applied(::typeof($f), args...) = $f(args...)
 end
 
 ###

--- a/test/macrotests.jl
+++ b/test/macrotests.jl
@@ -97,4 +97,10 @@ end
     @test bc.args[1].args isa Tuple{Applied, Int}
 end
 
+@testset "@~ and `@views`" begin
+    # https://github.com/JuliaArrays/LazyArrays.jl/issues/144
+    A = randn(6, 6)
+    @test copy(@views @~ exp.(A[1:2, 1:2])) == exp.(A[1:2, 1:2])
+end
+
 end  # module


### PR DESCRIPTION
There are two fixes in this patch.

The fist commit fix #144. This is a simple bug fix. This commit refactors the code inside `is_dotcall` into two functions `is_dotcall_nonop` and `is_dotcall_op` so that we can use the correct dot-op and dot-call applications everywhere.  It also uses `isoperator` now for the more correct detection of dot-op.

The second commit adds special-casing for `maybeview` etc. so that `applied(maybeview, args...)` directly calls `maybeview(args...)`. I'm not 100% sure if this is a reasonable approach. It could be a beginning endless whac-a-mole for registering eager applications. But it sounds like the most straightforward solution ATM.
