### PR TITLE
Recursive implementation of `searchsortedfirst` and `searchsortedlast`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LazyArrays"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "0.20.1"
+version = "0.20.2"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/lazyconcat.jl
+++ b/src/lazyconcat.jl
@@ -1012,7 +1012,10 @@ _searchsortedlast(a::Number, x) = 0 + (x ≥ a)
 searchsortedfirst(f::Vcat{<:Any,1}, x) =
     searchsortedfirst_recursive(0, x, arguments(f)...)
 
-@inline searchsortedfirst_recursive(n, x) = n + 1  # no more arguments
+searchsortedlast(f::Vcat{<:Any,1}, x) =
+    searchsortedlast_recursive(length(f), x, reverse(arguments(f))...)
+
+@inline searchsortedfirst_recursive(n, x) = n + 1
 
 @inline function searchsortedfirst_recursive(n, x, a, args...)
     m = length(a)
@@ -1021,13 +1024,13 @@ searchsortedfirst(f::Vcat{<:Any,1}, x) =
     return searchsortedfirst_recursive(n + m, x, args...)
 end
 
-function searchsortedlast(f::Vcat{<:Any,1}, x)
-    args = arguments(f)
-    for k in length(args):-1:2
-        r = _searchsortedlast(args[k], x)
-        r > 0 && return mapreduce(length,+, args[1:k-1]) + r
-    end
-    return _searchsortedlast(args[1], x)
+@inline searchsortedlast_recursive(n, x) = n
+
+@inline function searchsortedlast_recursive(n, x, a, args...)
+    n -= length(a)
+    r = _searchsortedlast(a, x)
+    r > 0 && return n + r
+    return searchsortedlast_recursive(n, x, args...)
 end
 
 searchsorted(f::Vcat{<:Any,1}, x) = searchsortedfirst(f, x):searchsortedlast(f,x)

--- a/src/lazyconcat.jl
+++ b/src/lazyconcat.jl
@@ -1009,15 +1009,16 @@ _searchsortedfirst(a::Number, x) = 1 + (x > a)
 _searchsortedlast(a, x) = searchsortedlast(a, x)
 _searchsortedlast(a::Number, x) = 0 + (x ≥ a)
 
-function searchsortedfirst(f::Vcat{<:Any,1}, x)
-    n = 0
-    for a in arguments(f)
-        m = length(a)
-        r = _searchsortedfirst(a, x)
-        r ≤ m && return n + r
-        n += m
-    end
-    return n+1
+searchsortedfirst(f::Vcat{<:Any,1}, x) =
+    searchsortedfirst_recursive(0, x, arguments(f)...)
+
+@inline searchsortedfirst_recursive(n, x) = n + 1  # no more arguments
+
+@inline function searchsortedfirst_recursive(n, x, a, args...)
+    m = length(a)
+    r = _searchsortedfirst(a, x)
+    r ≤ m && return n + r
+    return searchsortedfirst_recursive(n + m, x, args...)
 end
 
 function searchsortedlast(f::Vcat{<:Any,1}, x)

--- a/test/concattests.jl
+++ b/test/concattests.jl
@@ -552,12 +552,12 @@ import LazyArrays: MemoryLayout, DenseColumnMajor, PaddedLayout, materialize!, c
     end
 
     @testset "searchsorted" begin
-        a = Vcat(1:1_000_000, [10_000_000_000,12_000_000_000])
-        b = Vcat(1, 3:1_000_000)
-        @test searchsortedfirst(a, 6_000_000_001) == 1_000_001
-        @test searchsortedlast(a, 2) == 2
-        @test searchsortedfirst(b, 5) == 4
-        @test searchsortedlast(b, 1) == 1
+        a = Vcat(1:1_000_000, [10_000_000_000,12_000_000_000], 14_000_000_000)
+        b = Vcat(1, 3:1_000_000, [2_000_000, 3_000_000])
+        @test @inferred(searchsortedfirst(a, 6_000_000_001)) == 1_000_001
+        @test @inferred(searchsortedlast(a, 2)) == 2
+        @test @inferred(searchsortedfirst(b, 5)) == 4
+        @test @inferred(searchsortedlast(b, 1)) == 1
     end
 
     @testset "args with hcat and view" begin


### PR DESCRIPTION
Similarly to #133, this PR reimplements `searchsortedfirst` and `searchsortedlast` for concatenated arrays recursively.

As shown below, the changes can result in important performance gains from both functions, especially when the concatenated arrays are composed of different array types.

The example below was run on Julia 1.5.4, but results are similar on 1.6-beta1.

```julia
using BenchmarkTools
using LazyArrays
using StaticArrays

A = Vcat(
    collect(1:10),
    11:2:20,
    SVector{4}(22:25),
)

@assert issorted(A)
```

Before this PR:

```julia
julia> @btime searchsortedfirst($A, 4);
  11.841 ns (0 allocations: 0 bytes)

julia> @btime searchsortedfirst($A, 23);
  112.249 ns (4 allocations: 240 bytes)

julia> @btime searchsortedlast($A, 4);
  92.327 ns (4 allocations: 240 bytes)

julia> @btime searchsortedlast($A, 23);
  241.237 ns (4 allocations: 224 bytes)
```

After this PR:

```julia
julia> @btime searchsortedfirst($A, 4);
  8.244 ns (0 allocations: 0 bytes)

julia> @btime searchsortedfirst($A, 23);
  30.821 ns (0 allocations: 0 bytes)

julia> @btime searchsortedlast($A, 4);
  32.848 ns (0 allocations: 0 bytes)

julia> @btime searchsortedlast($A, 23);
  12.541 ns (0 allocations: 0 bytes)
```

This PR also fixes an issue in which the return type of `searchsortedlast` was not inferred, which explains in part its poor performance above. This is before the proposed changes:

```julia
julia> @code_warntype searchsortedlast(A, 23);
Variables
  #self#::Core.Compiler.Const(searchsortedlast, false)
  f::ApplyArray{Int64,1,typeof(vcat),Tuple{Array{Int64,1},StepRange{Int64,Int64},SArray{Tuple{4},Int64,1,4}}}
  x::Int64
  args::Tuple{Array{Int64,1},StepRange{Int64,Int64},SArray{Tuple{4},Int64,1,4}}
  @_5::Union{Nothing, Tuple{Int64,Int64}}
  k::Int64
  r::Int64

Body::Any
1 ─       (args = LazyArrays.arguments(f))
│   %2  = LazyArrays.length(args)::Core.Compiler.Const(3, false)
│   %3  = (%2:-1:2)::Core.Compiler.Const(3:-1:2, false)
│         (@_5 = Base.iterate(%3))
│   %5  = (@_5::Core.Compiler.Const((3, 3), false) === nothing)::Core.Compiler.Const(false, false)
│   %6  = Base.not_int(%5)::Core.Compiler.Const(true, false)
└──       goto #6 if not %6
2 ┄ %8  = @_5::Tuple{Int64,Int64}::Tuple{Int64,Int64}
│         (k = Core.getfield(%8, 1))
│   %10 = Core.getfield(%8, 2)::Int64
│   %11 = Base.getindex(args, k)::Union{StepRange{Int64,Int64}, SArray{Tuple{4},Int64,1,4}, Array{Int64,1}}
│         (r = LazyArrays._searchsortedlast(%11, x))
│   %13 = (r > 0)::Bool
└──       goto #4 if not %13
3 ─ %15 = args::Tuple{Array{Int64,1},StepRange{Int64,Int64},SArray{Tuple{4},Int64,1,4}}
│   %16 = (k - 1)::Int64
│   %17 = (1:%16)::Core.Compiler.PartialStruct(UnitRange{Int64}, Any[Core.Compiler.Const(1, false), Int64])
│   %18 = Base.getindex(%15, %17)::Tuple
│   %19 = LazyArrays.mapreduce(LazyArrays.length, LazyArrays.:+, %18)::Any
│   %20 = (%19 + r)::Any
└──       return %20
4 ─       (@_5 = Base.iterate(%3, %10))
│   %23 = (@_5 === nothing)::Bool
│   %24 = Base.not_int(%23)::Bool
└──       goto #6 if not %24
5 ─       goto #2
6 ┄ %27 = Base.getindex(args, 1)::Array{Int64,1}
│   %28 = LazyArrays._searchsortedlast(%27, x)::Int64
└──       return %28
```