### PR TITLE
Lazy ndgrid

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LazyArrays"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "0.21.9"
+version = "0.22.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/LazyArrays.jl
+++ b/src/LazyArrays.jl
@@ -76,6 +76,7 @@ include("lazyconcat.jl")
 include("lazysetoperations.jl")
 include("lazyoperations.jl")
 include("lazymacro.jl")
+include("ndgrid.jl")
 
 # support x^2
 Base.to_power_type(x::LazyArray) = x

--- a/src/ndgrid.jl
+++ b/src/ndgrid.jl
@@ -1,0 +1,80 @@
+#=
+ndgrid.jl
+lazy and non-lazy versions of ndgrid
+=#
+
+#using LazyArrays: Applied, ApplyArray
+
+export ndgrid, ndgrid_lazy
+
+"""
+    grid = ndgrid_repeat(v::AbstractVector, dims::Dims{D}, d::Int)
+Do the type of repeat needed for `ndgrid`, e.g., `repeat(x, 1, n)`,
+for arbitrary dimensions, where `1 ≤ d ≤ D` and `dims[d] == length(v)`.
+Output size is `dims`.
+"""
+function ndgrid_repeat(v::AbstractVector, dims::Dims{D}, d::Int) where D
+    @boundscheck checkbounds([dims...], d)
+    @boundscheck length(v) == dims[d] ||
+        throw(DimensionMismatch("$d $(dims[d]) $(length(v))"))
+    t1 = ntuple(i -> i == d ? length(v) : 1, Val(D)) # (1,…,1,n,1,…,1)
+    t2 = ntuple(i -> i == d ? 1 : dims[i], Val(D)) # (?,…,?,1,?,…,?)
+    repeat(reshape(v, t1), t2...)
+end
+
+
+"""
+    ndgrid(args::AbstractVector...)
+Returns tuple of `length(args)` arrays, each of size `tuple(length.(args)...)`.
+This method is provided for convenience and testing,
+but `ndgrid` is less efficient than broadcast so should be avoided.
+The tuple returned here requires `prod(length.(args)) * length(args)` memory;
+using `ndgrid_lazy` is an alternative that uses `O(length(args))` memory.
+"""
+function ndgrid(args::AbstractVector...)
+    fun = i -> ndgrid_repeat(args[i], length.(args), i)
+    ntuple(fun, Val(length(args)))
+end
+
+
+# lazy array method for a single element of the ndgrid tuple:
+
+const Repeat = Applied{A, typeof(ndgrid_repeat), Tuple{V,Dim,Int}} where
+    {A <: Any, V <: AbstractVector, Dim <: Dims{D} where D}
+Base.ndims(r::Repeat) = length(r.args[2])
+Base.size(r::Repeat) = r.args[2]
+Base.eltype(r::Repeat) = eltype(r.args[1])
+
+const RepeatA{T,N} = ApplyArray{T, N, typeof(ndgrid_repeat)}
+# Base.IndexStyle(RepeatA) = IndexCartesian() # default
+
+Base.@propagate_inbounds function Base.getindex(
+    r::RepeatA{T,N},
+    i::Vararg{Int,N},
+) where {T,N}
+    @boundscheck checkbounds(r, i...)
+    return @inbounds r.args[1][i[r.args[3]]]
+end
+
+
+"""
+    ndgrid_lazy(args::AbstractVector...)
+Returns tuple of lazy array `Repeat` items,
+avoiding the memory issues of `ndgrid`.
+
+# Examples
+```jldoctest
+julia> ndgrid_lazy(1:3, 1:2)
+([1 1; 2 2; 3 3], [1 2; 1 2; 1 2])
+
+julia> ndgrid_lazy(1:3, 1:2)[1]
+ndgrid_repeat(3-element UnitRange{Int64}, Tuple{Int64, Int64}, Int64):
+ 1  1
+ 2  2
+ 3  3
+```
+"""
+function ndgrid_lazy(args::AbstractVector...)
+    fun = i -> ApplyArray(ndgrid_repeat, args[i], length.(args), i)
+    return ntuple(fun, Val(length(args)))
+end

--- a/test/ndgrid.jl
+++ b/test/ndgrid.jl
@@ -1,0 +1,83 @@
+# ndgrid.jl
+# test lazy and non-lazy version
+
+using LazyArrays: ndgrid, ndgrid_lazy, ndgrid_repeat
+
+using Test: @test, @testset, @test_throws, @inferred
+
+@testset "ndgrid" begin
+
+    # easy test with vectors of the same type
+    xg, yg, zg = @inferred ndgrid(1:4, 5:7, 8:9)
+    @test xg == repeat(1:4, 1, 3, 2)
+    @test yg == repeat((5:7)', 4, 1, 2)
+
+    # harder test with vectors of different types
+    x = 1:4
+    y = [1//2, 3//4]
+    z = [:a, :b, :c]
+
+    @inferred ndgrid(x, y) # compiler figures out type,
+    @inferred ndgrid(x, z) # surprisingly
+
+    @test_throws BoundsError ndgrid_repeat(x, (4,2,3), 0)
+    @test_throws DimensionMismatch ndgrid_repeat(x, (4,2,3), 2)
+
+    @inferred ndgrid_repeat(x, (4,2,3), 1)
+    @inferred ndgrid_repeat(y, (4,2,3), 2)
+    @inferred ndgrid_repeat(z, (4,2,3), 3)
+#   xg, yg, zg = @inferred ndgrid(x, y, z) # @inferred fails here
+    xg, yg, zg = ndgrid(x, y, z)
+    @test zg == repeat(reshape(z, (1,1,3)), 4, 2, 1)
+end
+
+@testset "ndgrid_lazy" begin
+    x = 1:4
+    y = [1//2, 3//4]
+    z = [:a, :b, :c]
+    a = ndgrid(x, y)
+    b = @inferred ndgrid_lazy(x, y)
+    @test a == b
+    a = ndgrid(x, y, z)
+#   b = @inferred ndgrid_lazy(x, y, z) # @inferred fails here
+    b = ndgrid_lazy(x, y, z)
+    @test a == b
+
+    # indexing
+    (xn, _, _) = ndgrid(x, y, z)
+    (xl, _, _) = ndgrid_lazy(x, y, z)
+
+    @test xn == xl
+    @test xn[3] == xl[3]
+    @test xn[3] == xl[3]
+    @test xn[:] == xl[:]
+    @test size(xn) == size(xl)
+    @test ndims(xn) == ndims(xl)
+    @test xl isa AbstractArray
+
+    @test sizeof(xl) < 100 # small!
+end
+
+#=
+@which getindex(xn, 3) # calls Base
+@which getindex(xl, 1, 1, 1) # calls specialized getindex
+=#
+
+#=
+# uncomment this block for timing comparisons
+
+    x = 1:2^8
+    y = 1:2^9
+    z = 1:2^4
+    (xn, _, _) = ndgrid(x, y, z)
+    (xl, _, _) = ndgrid_lazy(x, y, z)
+    f = x -> sum(a -> a^2, x)
+    g = x -> @inbounds sum(a -> a^2, x)
+    @assert f(xl) ≈ f(xn) ≈ g(xl)
+
+using BenchmarkTools
+@btime f($xn) # 0.9 ms
+@btime f($xl) # 4.3 ms (much slower, but less memory...)
+@btime g($xn) # 0.9 ms
+@btime g($xl) # 4.3 ms (so inbounds did not help)
+=#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,7 @@ include("lazymultests.jl")
 include("concattests.jl")
 include("broadcasttests.jl")
 include("cachetests.jl")
+include("ndgrid.jl")
 
 @testset "Kron"  begin
     A = [1,2,3]


### PR DESCRIPTION
Here is an initial PR for adding lazy `ndgrid`.
Some questions:

Currently there is `ndgrid` and `ndgrid_lazy` method names.
If you prefer `ndgrid` for the lazy version of course that's fine.
Having the non-lazy version (with some name, somewhere) is helpful for testing.
I don't think we need the capitalized `Ndgrid` here because Base will *never* offer `ndgrid` :)

I'm unsure about bounds checking so please double check all that.

Also, if you have any ideas about how to accelerate it, please advise!
There are (commented out) timing tests in the test code that are about 4x slower which is tolerable, but any improvement would be welcome.  My guess is that `r.args[1][i[r.args[3]]]` may simply have that much overhead...

Do you want `meshgrid` too?  It's just one more line:
`meshgrid(y,x) = (ndgrid_lazy(x,y)[[2,1]]...,)`

If this gets merged we should advertise it:
https://discourse.julialang.org/t/meshgrid-function-in-julia/48679
https://stackoverflow.com/questions/44581049/utilizing-ndgrid-meshgrid-functionality-in-julia/44766347