### PR TITLE
Fix tests on Julia 1.8-beta1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 on:
-  - push
+  - push:
+      branches:
+        - main
   - pull_request
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '^1.7.0-0'
+          - '1' # Latest stable release
+          - '^1.8.0-0'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
-  - push:
-      branches:
-        - master
-  - pull_request:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   - push:
       branches:
         - master
-  - pull_request
+  - pull_request:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   - push:
       branches:
-        - main
+        - master
   - pull_request
 jobs:
   test:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LazyArrays"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "0.22.5"
+version = "0.22.6"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
@@ -12,7 +12,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-ArrayLayouts = "0.7.7"
+ArrayLayouts = "0.8"
 FillArrays = "0.12, 0.13"
 MacroTools = "0.5"
 MatrixFactorizations = "0.8.2"

--- a/src/LazyArrays.jl
+++ b/src/LazyArrays.jl
@@ -25,7 +25,7 @@ import Base: AbstractArray, AbstractMatrix, AbstractVector,
          AbstractMatrix, AbstractArray, checkindex, unsafe_length, OneTo, one, zero,
         to_shape, _sub2ind, print_matrix, print_matrix_row, print_matrix_vdots,
       checkindex, Slice, @propagate_inbounds, @_propagate_inbounds_meta,
-      _in_range, _range, _rangestyle, Ordered,
+      _in_range, _range, Ordered,
       ArithmeticWraps, floatrange, reverse, unitrange_last,
       AbstractArray, AbstractVector, axes, (:), _sub2ind_recurse, broadcast, promote_eltypeof,
       similar, @_gc_preserve_end, @_gc_preserve_begin,
@@ -37,7 +37,7 @@ import Base.Broadcast: BroadcastStyle, AbstractArrayStyle, Broadcasted, broadcas
                         combine_eltypes, DefaultArrayStyle, instantiate, materialize,
                         materialize!, eltypes
 
-import LinearAlgebra: AbstractTriangular, AbstractQ, checksquare, pinv, fill!, tilebufsize, Abuf, Bbuf, Cbuf, dot, factorize, qr, lu, cholesky,
+import LinearAlgebra: AbstractTriangular, AbstractQ, checksquare, pinv, fill!, tilebufsize, dot, factorize, qr, lu, cholesky,
                         norm2, norm1, normInf, normp, normMinusInf, diag, det, logabsdet, tr, AdjOrTrans, triu, tril,
                         lmul!, rmul!
 

--- a/test/applytests.jl
+++ b/test/applytests.jl
@@ -58,7 +58,7 @@ import ArrayLayouts: StridedLayout
         @test copyto!(b, a) == a == b
         @test copyto!(c, a) == a == c
         @test copyto!(similar(a), a) == a
-        if VERSION ≤ v"1.7.99"
+        if VERSION < v"1.8.0-"
             @test_throws ErrorException copyto!(c, Array(a))
         else
             @test_throws Base.CanonicalIndexError copyto!(c, Array(a))

--- a/test/applytests.jl
+++ b/test/applytests.jl
@@ -58,7 +58,11 @@ import ArrayLayouts: StridedLayout
         @test copyto!(b, a) == a == b
         @test copyto!(c, a) == a == c
         @test copyto!(similar(a), a) == a
-        @test_throws ErrorException copyto!(c, Array(a))
+        if VERSION ≤ v"1.7.99"
+            @test_throws ErrorException copyto!(c, Array(a))
+        else
+            @test_throws Base.CanonicalIndexError copyto!(c, Array(a))
+        end
     end
 
     @testset "view" begin

--- a/test/multests.jl
+++ b/test/multests.jl
@@ -955,8 +955,8 @@ end
        @test apply(*, Diagonal(Fill(2,10)), Fill(3,10)) ≡ Diagonal(Fill(2,10))  * Fill(3,10) ≡ Fill(6,10)
        @test apply(*, Diagonal(Fill(2,10)), Fill(3,10,3)) ≡ Diagonal(Fill(2,10))  * Fill(3,10,3) ≡ Fill(6,10,3)
        @test apply(*,Fill(3,10,10),Fill(3,10)) ≡ Fill(3,10,10) * Fill(3,10) ≡ Fill(90,10)
-       @test apply(*, Eye(10), Ones(10)) ≡ Ones(10)
-       @test apply(*, Eye(10), Eye(10)) ≡ Eye(10)
+       @test apply(*, Eye(10), Ones(10)) == Ones(10)
+       @test apply(*, Eye(10), Eye(10)) == Eye(10)
     end
 
     @testset "ApplyArray MulTest" begin

--- a/test/multests.jl
+++ b/test/multests.jl
@@ -955,8 +955,8 @@ end
        @test apply(*, Diagonal(Fill(2,10)), Fill(3,10)) ≡ Diagonal(Fill(2,10))  * Fill(3,10) ≡ Fill(6,10)
        @test apply(*, Diagonal(Fill(2,10)), Fill(3,10,3)) ≡ Diagonal(Fill(2,10))  * Fill(3,10,3) ≡ Fill(6,10,3)
        @test apply(*,Fill(3,10,10),Fill(3,10)) ≡ Fill(3,10,10) * Fill(3,10) ≡ Fill(90,10)
-       @test apply(*, Eye(10), Ones(10)) == Ones(10)
-       @test apply(*, Eye(10), Eye(10)) == Eye(10)
+       @test apply(*, Eye(10), Ones(10)) ≡ Ones(10)
+       @test apply(*, Eye(10), Eye(10)) ≡ Eye(10)
     end
 
     @testset "ApplyArray MulTest" begin

--- a/test/paddedtests.jl
+++ b/test/paddedtests.jl
@@ -207,7 +207,7 @@ paddeddata(a::PaddedPadded) = a
             @test a .* v == v .* a
 
             @test n .+ n ≡ Vcat(2,Zeros{Int}(3))
-            @test n .+ v ≡ v .+ n ≡ Vcat(2,1:3)
+            @test n .+ v == v .+ n == Vcat(2,1:3)
             @test n .+ b == b .+ n
             @test n .+ a == a .+ n
             @test n .+ c == c .+ n

--- a/test/paddedtests.jl
+++ b/test/paddedtests.jl
@@ -207,7 +207,8 @@ paddeddata(a::PaddedPadded) = a
             @test a .* v == v .* a
 
             @test n .+ n ≡ Vcat(2,Zeros{Int}(3))
-            @test n .+ v == v .+ n == Vcat(2,1:3)
+            @test n .+ v ≡ n .+ v
+            @test n .+ v ≡ v .+ n ≡ Vcat(2,1:3)
             @test n .+ b == b .+ n
             @test n .+ a == a .+ n
             @test n .+ c == c .+ n


### PR DESCRIPTION
I've tested these changes on Julia 1.6, 1.7 and 1.8-beta1.

I've also changed

```
on:
  - push
  - pull_request
```
to
```
on:
  push:
    branches:
      - master
  pull_request:
```
to avoid triggering the jobs for pushes and pull requests at the same time. See, for example, https://github.com/JuliaData/CSV.jl/blob/2c02394b4ce11ee673ed1b6d0c811a98316bc2f9/.github/workflows/ci.yml#L3-L5