### PR TITLE
remove unbound type parameters

### DIFF
--- a/src/lazyapplying.jl
+++ b/src/lazyapplying.jl
@@ -96,7 +96,7 @@ end
 
 
 
-similar(M::Applied{<:AbstractArrayApplyStyle}, ::Type{T}, axes) where {T,N} = Array{T}(undef, length.(axes))
+similar(M::Applied{<:AbstractArrayApplyStyle}, ::Type{T}, axes) where {T} = Array{T}(undef, length.(axes))
 similar(M::Applied{<:AbstractArrayApplyStyle}, ::Type{T}) where T = similar(M, T, axes(M))
 similar(M::Applied) = similar(M, eltype(M))
 

--- a/src/lazybroadcasting.jl
+++ b/src/lazybroadcasting.jl
@@ -124,10 +124,10 @@ end
 
 
 BroadcastStyle(::Type{<:LazyArray{<:Any,N}}) where N = LazyArrayStyle{N}()
-BroadcastStyle(::Type{<:Adjoint{<:Any,<:LazyVector{<:Any}}}) where N = LazyArrayStyle{2}()
-BroadcastStyle(::Type{<:Transpose{<:Any,<:LazyVector{<:Any}}}) where N = LazyArrayStyle{2}()
-BroadcastStyle(::Type{<:Adjoint{<:Any,<:LazyMatrix{<:Any}}}) where N = LazyArrayStyle{2}()
-BroadcastStyle(::Type{<:Transpose{<:Any,<:LazyMatrix{<:Any}}}) where N = LazyArrayStyle{2}()
+BroadcastStyle(::Type{<:Adjoint{<:Any,<:LazyVector{<:Any}}}) = LazyArrayStyle{2}()
+BroadcastStyle(::Type{<:Transpose{<:Any,<:LazyVector{<:Any}}}) = LazyArrayStyle{2}()
+BroadcastStyle(::Type{<:Adjoint{<:Any,<:LazyMatrix{<:Any}}}) = LazyArrayStyle{2}()
+BroadcastStyle(::Type{<:Transpose{<:Any,<:LazyMatrix{<:Any}}}) = LazyArrayStyle{2}()
 BroadcastStyle(::Type{<:SubArray{<:Any,1,<:LazyMatrix,<:Tuple{Slice,Any}}}) = LazyArrayStyle{1}()
 BroadcastStyle(L::LazyArrayStyle{N}, ::StaticArrayStyle{N}) where N = L
 BroadcastStyle(L::LazyArrayStyle{N}, ::StructuredMatrixStyle)  where N = L
@@ -310,7 +310,7 @@ for op in (:+, :-, :*, :\, :/)
     end
 end
 
-function _broadcastarray_summary(io::IO, ::typeof(Base.literal_pow), ::Base.RefValue{typeof(^)}, x, ::Base.RefValue{Val{K}}) where {N,K}
+function _broadcastarray_summary(io::IO, ::typeof(Base.literal_pow), ::Base.RefValue{typeof(^)}, x, ::Base.RefValue{Val{K}}) where {K}
     print(io, "(")
     summary(io, x)
     print(io, ") .^ $K")

--- a/src/lazyconcat.jl
+++ b/src/lazyconcat.jl
@@ -138,7 +138,7 @@ end
 @inline eltype(A::Applied{<:Any,typeof(hcat)}) = promote_type(map(eltype,A.args)...)
 ndims(::Applied{<:Any,typeof(hcat)}) = 2
 size(f::Applied{<:Any,typeof(hcat)}) = (size(f.args[1],1), +(map(a -> size(a,2), f.args)...))
-Base.IndexStyle(::Type{<:Hcat}) where T = Base.IndexCartesian()
+Base.IndexStyle(::Type{<:Hcat}) = Base.IndexCartesian()
 
 @inline hcat_getindex(f, k, j::Integer) = hcat_getindex_recursive(f, (k, j), f.args...)
 
@@ -489,7 +489,7 @@ end
 ######
 
 BroadcastStyle(::Type{<:Vcat{<:Any,N}}) where N = LazyArrayStyle{N}()
-BroadcastStyle(::Type{<:Hcat{<:Any}}) where N = LazyArrayStyle{2}()
+BroadcastStyle(::Type{<:Hcat{<:Any}}) = LazyArrayStyle{2}()
 
 # This is if we broadcast a function on a mixed concat f.([1; [2,3]]) 
 # such that f returns a vector, e.g., f(1) == [1,2], we don't want

--- a/src/linalg/inv.jl
+++ b/src/linalg/inv.jl
@@ -162,8 +162,8 @@ getindex(Ai::SubArray{<:Any,2,<:InvMatrix}, ::Colon, j::Integer) = parent(Ai)[:,
 @propagate_inbounds getindex(A::PInvMatrix{T}, k::Integer, j::Integer) where T = A[:,j][k]
 @propagate_inbounds getindex(A::InvMatrix{T}, k::Integer, j::Integer) where T = A[:,j][k]
 
-getindex(L::ApplyMatrix{<:Any,typeof(\)}, ::Colon, j::Integer) where T = L.args[1] \ L.args[2][:,j]
-getindex(L::ApplyMatrix{<:Any,typeof(\)}, k::Integer, j::Integer) where T = L[:,j][k]
+getindex(L::ApplyMatrix{<:Any,typeof(\)}, ::Colon, j::Integer) = L.args[1] \ L.args[2][:,j]
+getindex(L::ApplyMatrix{<:Any,typeof(\)}, k::Integer, j::Integer) = L[:,j][k]
 
-getindex(L::ApplyMatrix{<:Any,typeof(/)}, k::Integer, ::Colon) where T = permutedims(L.args[2]) \ L.args[1][k,:]
-getindex(L::ApplyMatrix{<:Any,typeof(/)}, k::Integer, j::Integer) where T = L[k,:][j]
+getindex(L::ApplyMatrix{<:Any,typeof(/)}, k::Integer, ::Colon) = permutedims(L.args[2]) \ L.args[1][k,:]
+getindex(L::ApplyMatrix{<:Any,typeof(/)}, k::Integer, j::Integer) = L[k,:][j]


### PR DESCRIPTION
I didn't check, but unbound type parameters often cause performance issues, so this may not be merely cosmetic.