### PR TITLE
WIP: Fix getindex of cached arrays not following MemoryLayout

### DIFF
--- a/src/cache.jl
+++ b/src/cache.jl
@@ -95,9 +95,30 @@ end
 
 getindex(A::AbstractCachedMatrix, I::Integer) = A[Base._to_subscript_indices(A, I)...]
 
-@inline getindex(A::AbstractCachedMatrix, kr::AbstractUnitRange, jr::AbstractUnitRange) = layout_getindex(A, kr, jr)
-@inline getindex(A::AbstractCachedMatrix, kr::AbstractVector, jr::AbstractVector) = layout_getindex(A, kr, jr)
-@inline getindex(A::AbstractCachedMatrix, k::Integer, jr::AbstractVector) = layout_getindex(A, k, jr)
+@inline function getindex(A::AbstractCachedMatrix, k::Integer, jr::AbstractUnitRange)
+    resizedata!(A, k, maximum(jr))
+    layout_getindex(A.data, k, jr)
+end
+@inline function getindex(A::AbstractCachedMatrix, kr::AbstractUnitRange, j::Integer)
+    resizedata!(A, maximum(kr), j)
+    layout_getindex(A.data, kr, j)
+end
+@inline function getindex(A::AbstractCachedMatrix, kr::AbstractUnitRange, jr::AbstractUnitRange)
+    resizedata!(A, maximum(kr), maximum(jr))
+    layout_getindex(A.data, kr, jr)
+end
+@inline function getindex(A::AbstractCachedMatrix, kr::AbstractVector, jr::AbstractVector)
+    resizedata!(A, maximum(kr), maximum(jr))
+    layout_getindex(A.data, kr, jr)
+end
+@inline function getindex(A::AbstractCachedMatrix, k::Integer, jr::AbstractVector)
+    resizedata!(A, k, maximum(jr))
+    layout_getindex(A.data, k, jr)
+end
+@inline function getindex(A::AbstractCachedMatrix, kr::AbstractVector, j::Integer)
+    resizedata!(A, maximum(kr), j)
+    layout_getindex(A.data, k, jr)
+end
 @inline getindex(A::AbstractCachedMatrix, k::Integer, ::Colon) = layout_getindex(A, k, :)
 @inline getindex(A::AbstractCachedMatrix, kr::AbstractVector, ::Colon) = layout_getindex(A, kr, :)
 @inline getindex(A::AbstractCachedMatrix, kr::AbstractUnitRange, ::Colon) = layout_getindex(A, kr, :)


### PR DESCRIPTION
@dlfivefifty As discussed in [this PR](https://github.com/JuliaLinearAlgebra/InfiniteLinearAlgebra.jl/pull/125#discussion_r1173841087) I will try retaining bandedness of cached arrays. The workaround I have been using defines getindex to first resize, then getindex afterwards.

This doesn't address the issue I found in https://github.com/JuliaArrays/LazyArrays.jl/issues/247, which seems to be triggered by `display()`. 

Since BandedMatrices is not part of the dependencies of this package and we likely don't want to add it, it's a bit weird to write tests for this but I think `UpperTriangular` and `SparseArray` serve as a reasonable stand-in.