### PR TITLE
replace AbstractTriangular by UpperOrLowerTriangular

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LazyArrays"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/LazyArrays.jl
+++ b/src/LazyArrays.jl
@@ -37,9 +37,18 @@ import Base.Broadcast: BroadcastStyle, AbstractArrayStyle, Broadcasted, broadcas
                         combine_eltypes, DefaultArrayStyle, instantiate, materialize,
                         materialize!, eltypes
 
-import LinearAlgebra: AbstractTriangular, AbstractQ, checksquare, pinv, fill!, tilebufsize, dot, factorize, qr, lu, cholesky,
+import LinearAlgebra: AbstractQ, checksquare, pinv, fill!, tilebufsize, dot, factorize, qr, lu, cholesky,
                         norm2, norm1, normInf, normp, normMinusInf, diag, det, logabsdet, tr, AdjOrTrans, triu, tril,
                         lmul!, rmul!, StructuredMatrixStyle
+
+if VERSION ≥ v"1.11.0-DEV.21"
+    using LinearAlgebra: UpperOrLowerTriangular
+else
+    const UpperOrLowerTriangular{T,S} = Union{LinearAlgebra.UpperTriangular{T,S},
+                                              LinearAlgebra.UnitUpperTriangular{T,S},
+                                              LinearAlgebra.LowerTriangular{T,S},
+                                              LinearAlgebra.UnitLowerTriangular{T,S}}
+end
 
 import LinearAlgebra.BLAS: BlasFloat, BlasReal, BlasComplex
 

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -168,7 +168,7 @@ end
 @inline _isfinite_getindex(A::Adjoint{T, <:AbstractCachedVector{T}}, kr, maxkr::Int) where T = conj(parent(A)[kr])
 
 
-for Wrap in (:AbstractTriangular, :AdjOrTrans)
+for Wrap in (:UpperOrLowerTriangular, :AdjOrTrans)
     @eval begin
         @inline getindex(A::$Wrap{T, <:AbstractCachedArray{T}}, k::Integer, jr::AbstractUnitRange) where T = _isfinite_getindex(A, k, jr, k, maximum(jr))
         @inline getindex(A::$Wrap{T, <:AbstractCachedArray{T}}, kr::AbstractUnitRange, j::Integer) where T = _isfinite_getindex(A, kr, j, maximum(kr), j)


### PR DESCRIPTION
Copy over the changes from https://github.com/JuliaLinearAlgebra/ArrayLayouts.jl/commit/32e5ab8f00ab87162c93991509ee1a43c4f0e438. This fixes the downstream test set for `InfiniteLinearAlgebra` (failure seen in https://github.com/JuliaArrays/FillArrays.jl/actions/runs/5521409087/jobs/10069471635?pr=277)