### PR TITLE
Move `StaticArrays` to an extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 MatrixFactorizations = "a3b82374-2e81-5b9e-98ce-41277c0e4c87"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [weakdeps]
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LazyArrays"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "1.2.2"
+version = "1.3.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
@@ -9,7 +9,12 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 MatrixFactorizations = "a3b82374-2e81-5b9e-98ce-41277c0e4c87"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[weakdeps]
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[extensions]
+LazyArraysStaticArraysExt = "StaticArrays"
 
 [compat]
 Aqua = "0.6"
@@ -23,8 +28,9 @@ julia = "1.6"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [targets]
-test = ["Aqua", "Base64", "Tracker", "Test"]
+test = ["Aqua", "Base64", "StaticArrays", "Tracker", "Test"]

--- a/ext/LazyArraysStaticArraysExt.jl
+++ b/ext/LazyArraysStaticArraysExt.jl
@@ -1,0 +1,15 @@
+module LazyArraysStaticArraysExt
+
+using LazyArrays
+using LazyArrays: LazyArrayStyle
+using StaticArrays
+using StaticArrays: StaticArrayStyle
+
+function LazyArrays._vcat_layout_broadcasted((Ahead,Atail)::Tuple{SVector{M},Any},
+				(Bhead,Btail)::Tuple{SVector{M},Any}, op, A, B) where M
+	Vcat(op.(Ahead,Bhead), op.(Atail,Btail))
+end
+
+Base.BroadcastStyle(L::LazyArrayStyle{N}, ::StaticArrayStyle{N}) where N = L
+
+end

--- a/src/LazyArrays.jl
+++ b/src/LazyArrays.jl
@@ -3,7 +3,7 @@ module LazyArrays
 # Use README as the docstring of the module:
 @doc read(joinpath(dirname(@__DIR__), "README.md"), String) LazyArrays
 
-using Base, Base.Broadcast, LinearAlgebra, FillArrays, StaticArrays, ArrayLayouts, MatrixFactorizations, SparseArrays
+using Base, Base.Broadcast, LinearAlgebra, FillArrays, ArrayLayouts, MatrixFactorizations, SparseArrays
 import LinearAlgebra.BLAS
 
 import Base: AbstractArray, AbstractMatrix, AbstractVector,
@@ -54,8 +54,6 @@ import LinearAlgebra.BLAS: BlasFloat, BlasReal, BlasComplex
 
 import FillArrays: AbstractFill, getindex_value
 
-import StaticArrays: StaticArrayStyle
-
 import ArrayLayouts: MatMulVecAdd, MatMulMatAdd, MulAdd, Lmul, Rmul, Ldiv, Dot, Mul, _inv,
                         transposelayout, conjlayout, sublayout, triangularlayout, triangulardata,
                         reshapedlayout, diagonallayout, tridiagonallayout, symtridiagonallayout, bidiagonallayout, symmetriclayout, hermitianlayout,
@@ -94,5 +92,9 @@ map(::typeof(length), A::BroadcastVector{<:Zeros,Type{Zeros}}) = A.args[1]
 map(::typeof(length), A::BroadcastVector{<:Vcat,Type{Vcat}}) = broadcast(+,map.(length,A.args)...)
 broadcasted(::LazyArrayStyle{1}, ::typeof(length), A::BroadcastVector{OneTo{Int},Type{OneTo}}) = A.args[1]
 broadcasted(::LazyArrayStyle{1}, ::typeof(length), A::BroadcastVector{<:Fill,Type{Fill},<:NTuple{2,Any}}) = A.args[2]
+
+if !isdefined(Base, :get_extension)
+    include("../ext/LazyArraysStaticArraysExt.jl")
+end
 
 end # module

--- a/src/lazybroadcasting.jl
+++ b/src/lazybroadcasting.jl
@@ -129,7 +129,6 @@ BroadcastStyle(::Type{<:Transpose{<:Any,<:LazyVector{<:Any}}}) = LazyArrayStyle{
 BroadcastStyle(::Type{<:Adjoint{<:Any,<:LazyMatrix{<:Any}}}) = LazyArrayStyle{2}()
 BroadcastStyle(::Type{<:Transpose{<:Any,<:LazyMatrix{<:Any}}}) = LazyArrayStyle{2}()
 BroadcastStyle(::Type{<:SubArray{<:Any,1,<:LazyMatrix,<:Tuple{Slice,Any}}}) = LazyArrayStyle{1}()
-BroadcastStyle(L::LazyArrayStyle{N}, ::StaticArrayStyle{N}) where N = L
 BroadcastStyle(L::LazyArrayStyle{N}, ::StructuredMatrixStyle)  where N = L
 
 

--- a/src/lazyconcat.jl
+++ b/src/lazyconcat.jl
@@ -597,7 +597,6 @@ function _vcat_layout_broadcasted((Ahead,Atail)::Tuple{Number,Any}, (Bhead,Btail
 end
 
 _vcat_layout_broadcasted((Ahead,Atail)::Tuple{Number,Any}, (Bhead,Btail)::Tuple{Number,Any}, op, A, B) = Vcat(op.(Ahead,Bhead), op.(Atail,Btail))
-_vcat_layout_broadcasted((Ahead,Atail)::Tuple{SVector{M},Any}, (Bhead,Btail)::Tuple{SVector{M},Any}, op, A, B) where M = Vcat(op.(Ahead,Bhead), op.(Atail,Btail))
 
 
 broadcasted(::LazyArrayStyle, op, a::Vcat{<:Any,N}, b::AbstractArray{<:Any,N}) where N = layout_broadcasted(op, a, b)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,12 @@ import ArrayLayouts: OnesLayout
 
 using Aqua
 @testset "Project quality" begin
-    Aqua.test_all(LazyArrays, ambiguities=false, piracy=false)
+    Aqua.test_all(LazyArrays, ambiguities=false, piracy=false,
+        # Project.toml formatting issue on v1.6
+        # Pkg issue: https://github.com/JuliaLang/Pkg.jl/issues/3481
+        # Aqua workaround: https://github.com/JuliaTesting/Aqua.jl/issues/105#issuecomment-1551405866
+        # we only check the formatting on more recent versions
+        project_toml_formatting = VERSION>=v"1.7")
 end
 
 @testset "Lazy MemoryLayout" begin


### PR DESCRIPTION
This removes the hard dependency on `StaticArrays`, as well as improves package load times.
On master
```julia
julia> @time using LazyArrays
  1.921267 seconds (3.58 M allocations: 330.500 MiB, 5.15% gc time, 0.29% compilation time)
```
This PR
```julia
julia> @time using LazyArrays
  1.333925 seconds (2.38 M allocations: 248.581 MiB, 5.93% gc time)
```
Removing the hard dependency means that one may use this package even when `StaticArrays` is broken (e.g. on nightly).