### PR TITLE
Version-limit pointer-based vcat_copyto

### DIFF
--- a/src/lazyconcat.jl
+++ b/src/lazyconcat.jl
@@ -255,7 +255,10 @@ function vcat_copyto!(dest::AbstractMatrix, arrays...)
 end
 
 function vcat_copyto!(arr::AbstractVector, arrays...)
-    n = sum(length, arrays)
+    n = 0
+    for a in arrays
+        n += length(a)
+    end
     n == length(arr) || throw(DimensionMismatch("destination must have length equal to sums of concatenated vectors"))
 
     i = firstindex(arr)

--- a/src/lazyconcat.jl
+++ b/src/lazyconcat.jl
@@ -255,20 +255,20 @@ function vcat_copyto!(dest::AbstractMatrix, arrays...)
 end
 
 function vcat_copyto!(arr::AbstractVector, arrays...)
-    n = 0
-    for a in arrays
-        n += length(a)
-    end
+    n = sum(length, arrays)
     n == length(arr) || throw(DimensionMismatch("destination must have length equal to sums of concatenated vectors"))
 
-    i = 0
-    @inbounds for a in arrays
+    i = firstindex(arr)
+    for a in arrays
         m = length(a)
-        copyto!(view(arr,i+1:i+m), a)
+        copyto!(view(arr, range(i, length=m)), a)
         i += m
     end
     arr
 end
+
+# The following provides no performance benefit on Julia v1.10.0-rc2
+@static if VERSION < v"1.10-"
 
 function vcat_copyto!(arr::Vector{T}, arrays::Vector{T}...) where T
     n = 0
@@ -308,6 +308,8 @@ function vcat_copyto!(arr::Vector{T}, arrays::Vector{T}...) where T
     end
     @_gc_preserve_end t
     return arr
+end
+
 end
 
 # special case for adjoints of hcat. This is useful for catching fast paths

--- a/test/concattests.jl
+++ b/test/concattests.jl
@@ -37,7 +37,7 @@ import LazyArrays: MemoryLayout, DenseColumnMajor, materialize!, call, paddeddat
             b = Array{Int}(undef, 30)
             copyto!(b, A)
             @test_broken @allocated(copyto!(b, A)) == 0
-            @test @allocated(copyto!(b, A)) ≤ 200
+            @test @allocated(copyto!(b, A)) ≤ 250
             @test b == vcat(A.args...)
             @test copy(A) === A
             @test vec(A) === A

--- a/test/concattests.jl
+++ b/test/concattests.jl
@@ -37,7 +37,7 @@ import LazyArrays: MemoryLayout, DenseColumnMajor, materialize!, call, paddeddat
             b = Array{Int}(undef, 30)
             copyto!(b, A)
             @test_broken @allocated(copyto!(b, A)) == 0
-            @test @allocated(copyto!(b, A)) ≤ 250
+            @test @allocated(copyto!(b, A)) ≤ 200
             @test b == vcat(A.args...)
             @test copy(A) === A
             @test vec(A) === A


### PR DESCRIPTION
The `vcat_copyto!` implementation for `Vector`s relies on unstable internals, and on v1.10 I find no difference in performance between this and the fallback method for `AbstractVector`s that uses `copyto!`. There is a difference on v1.9, so I've limited this method to Julia versions less than v1.10.

I've also removed the `@inbounds` annotation in the fallback method, as this was not making any difference to performance.

This should resolve a breakage on nightly, where `jl_array_ptr_copy` is apparently unavailable.