### PR TITLE
Update some broken tests

### DIFF
--- a/test/infinitearrays.jl
+++ b/test/infinitearrays.jl
@@ -7,7 +7,6 @@ module InfiniteArrays
     Base.length(r::AbstractInfUnitRange) = ℵ₀
     Base.size(r::AbstractInfUnitRange) = (ℵ₀,)
     Base.last(r::AbstractInfUnitRange) = ℵ₀
-    Base.axes(r::AbstractInfUnitRange) = (OneToInf(),)
 
     Base.IteratorSize(::Type{<:AbstractInfUnitRange}) = Base.IsInfinite()
 

--- a/test/paddedtests.jl
+++ b/test/paddedtests.jl
@@ -302,7 +302,7 @@ paddeddata(a::PaddedPadded) = a
         @test paddeddata(a) == [1 2 3; 4 5 6]
 
         # need to add bounds checking
-        @test_broken ApplyArray(setindex, Zeros(5,5), [1 2; 4 5], 2:3, 3:5)
+        @test_broken (try ApplyArray(setindex, Zeros(5,5), [1 2; 4 5], 2:3, 3:6) catch e; e; end) isa BoundsError
 
         @test PaddedArray(1, 3) == PaddedVector(1,3) == [1; zeros(2)]
         @test PaddedArray(1, 3, 3) == PaddedMatrix(1, 3, 3) == [1 zeros(1,2); zeros(2,3)]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -388,7 +388,7 @@ end
     @test rowsupport(D,3) === colsupport(D,3) === 3
     Z = Zeros(5)
     @test rowsupport(Z,1) === colsupport(Z,1) === 1:0
-    @test_broken cache(D)
+
     C = cache(Array,D);
     @test colsupport(C,2) === 2:2
     @test @inferred(colsupport(C,1)) === 1:1


### PR DESCRIPTION
`@test_broken ex` requires that `ex` evaluates to a `Bool`, so expressions like `@test_broken array` are inherently malformed. This used to pass on older versions of Julia, as `@test_broken` used to treat non-`false` results as `true`, but on recent versions (I think v1.10 and above) this explicitly requires a `Bool`.

With this change, all tests pass on nightly.