### PR TITLE
Specialize last for BroadcastArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LazyArrays"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "1.8.3"
+version = "1.9.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/lazybroadcasting.jl
+++ b/src/lazybroadcasting.jl
@@ -86,7 +86,7 @@ Broadcasted(A::SubArray{<:Any,N,<:BroadcastArray}) where N = broadcasted(A)::Bro
 axes(A::BroadcastArray) = axes(broadcasted(A))
 size(A::BroadcastArray) = map(length, axes(A))
 
-last(A::BroadcastArray) = foldl(A.f, last.(A.args))
+last(A::BroadcastArray) = A.f(last.(A.args)...)
 
 @propagate_inbounds getindex(A::BroadcastArray{T,N}, kj::Vararg{Int,N}) where {T,N} = convert(T,broadcasted(A)[kj...])::T
 

--- a/src/lazybroadcasting.jl
+++ b/src/lazybroadcasting.jl
@@ -86,6 +86,7 @@ Broadcasted(A::SubArray{<:Any,N,<:BroadcastArray}) where N = broadcasted(A)::Bro
 axes(A::BroadcastArray) = axes(broadcasted(A))
 size(A::BroadcastArray) = map(length, axes(A))
 
+last(A::BroadcastArray) = foldl(A.f, last.(A.args))
 
 @propagate_inbounds getindex(A::BroadcastArray{T,N}, kj::Vararg{Int,N}) where {T,N} = convert(T,broadcasted(A)[kj...])::T
 

--- a/test/broadcasttests.jl
+++ b/test/broadcasttests.jl
@@ -79,6 +79,19 @@ import Base: broadcasted
             @test eltype(B) == Float64
             @test B[1] ≡ 3.0
         end
+
+        @testset "infinite" begin
+            struct Wrapper{T,A<:AbstractVector{T}} <:AbstractVector{T}
+                r :: A
+            end
+            Base.size(w::Wrapper) = size(w.r)
+            Base.getindex(w::Wrapper, i::Int) = getindex(w.r, i)
+            Base.last(w::Wrapper) = last(w.r)
+            r = InfiniteArrays.OneToInf()
+            B = BroadcastArray(-, Wrapper(r), 2)
+            @test first(B) == -1
+            @test last(B) == last(r)
+        end
     end
 
     @testset "vector*matrix broadcasting #27" begin

--- a/test/broadcasttests.jl
+++ b/test/broadcasttests.jl
@@ -22,11 +22,13 @@ import Base: broadcasted
         @test Matrix(B) == exp.(A)
         @test B[1] == exp(A[1,1])
         @test B[7] == exp(A[1,2])
+        @test last(B) == exp(last(A))
 
         C = BroadcastArray(+, A, 2)
         @test C == A .+ 2
         D = BroadcastArray(+, A, C)
         @test D == A + C
+        @test last(C) == last(A) + 2
 
         @test sum(B) ≈ sum(exp, A)
         @test sum(C) ≈ sum(A .+ 2)

--- a/test/broadcasttests.jl
+++ b/test/broadcasttests.jl
@@ -90,6 +90,8 @@ import Base: broadcasted
             g(x,y) = x^2 + y^3
             B = BroadcastArray(g, [1 2; 3 4], [1 2; 3 4;;;])
             @test last(B) == B[end] == g(4,4)
+            B = BroadcastArray(+, [1,2], [5,6]')
+            @test last(B) == B[end] == 2+6
         end
 
         @testset "infinite" begin

--- a/test/broadcasttests.jl
+++ b/test/broadcasttests.jl
@@ -82,6 +82,16 @@ import Base: broadcasted
             @test B[1] ≡ 3.0
         end
 
+        @testset "last" begin
+            B = BroadcastArray(*, [1 2; 3 4], [5,6]')
+            @test last(B) == B[end] == 4*6
+            B = BroadcastArray(*, [1 2; 3 4], [5,6])
+            @test last(B) == B[end] == 4*6
+            g(x,y) = x^2 + y^3
+            B = BroadcastArray(g, [1 2; 3 4], [1 2; 3 4;;;])
+            @test last(B) == B[end] == g(4,4)
+        end
+
         @testset "infinite" begin
             struct Wrapper{T,A<:AbstractVector{T}} <:AbstractVector{T}
                 r :: A

--- a/test/cachetests.jl
+++ b/test/cachetests.jl
@@ -2,10 +2,6 @@ using LazyArrays, FillArrays, LinearAlgebra, ArrayLayouts, StaticArrays, SparseA
 import LazyArrays: CachedArray, CachedMatrix, CachedVector, PaddedLayout, CachedLayout, resizedata!, zero!,
                     CachedAbstractArray, CachedAbstractVector, CachedAbstractMatrix, AbstractCachedArray, AbstractCachedMatrix
 
-include("infinitearrays.jl")
-using .InfiniteArrays
-using Infinities
-
 @testset "Cache" begin
     @testset "basics" begin
         A = 1:10

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,10 @@ end
     end
 end
 
+include("infinitearrays.jl")
+using .InfiniteArrays
+using Infinities
+
 include("applytests.jl")
 include("multests.jl")
 include("ldivtests.jl")


### PR DESCRIPTION
This makes it easier to work with infinite arrays, as currently it falls back to indexing, and indexing with an infinity fails.