### PR TITLE
Make tests modular

### DIFF
--- a/test/addtests.jl
+++ b/test/addtests.jl
@@ -1,4 +1,7 @@
+module AddTests
+
 using LazyArrays, Test
+using LinearAlgebra
 import LazyArrays: Add, AddArray, MulAdd, materialize!, MemoryLayout, ApplyLayout
 
 @testset "Add/Subtract" begin
@@ -300,4 +303,6 @@ import LazyArrays: Add, AddArray, MulAdd, materialize!, MemoryLayout, ApplyLayou
             @test C*B ≈ (-A) * 3A
         end
     end
-end
+end # testset
+
+end # module

--- a/test/applytests.jl
+++ b/test/applytests.jl
@@ -1,7 +1,10 @@
+module ApplyTests
+
 using LazyArrays, FillArrays, ArrayLayouts, Test
 import LazyArrays: materialize, broadcasted, DefaultApplyStyle, Applied, arguments,
             ApplyArray, ApplyMatrix, ApplyVector, LazyArrayApplyStyle, ApplyLayout, call
 import ArrayLayouts: StridedLayout
+using LinearAlgebra
 
 @testset "Applying" begin
     @testset "Applied" begin
@@ -112,4 +115,6 @@ import ArrayLayouts: StridedLayout
         @test arguments(R) == (rot180(A), rot180(B))
         @test R ≈ rot180(A*B)
     end
-end
+end # testset
+
+end # module

--- a/test/benchmarktests.jl
+++ b/test/benchmarktests.jl
@@ -23,4 +23,4 @@ end
     A = Hcat(1:10, 2:11)
     b = Array{Int}(undef, 10, 2)
     @test @belapsed(copyto!($b,$A)) < @belapsed(hcat($A.args...))
-en
+end

--- a/test/cachetests.jl
+++ b/test/cachetests.jl
@@ -1,6 +1,12 @@
+module CacheTests
+
 using LazyArrays, FillArrays, LinearAlgebra, ArrayLayouts, StaticArrays, SparseArrays, Test
 import LazyArrays: CachedArray, CachedMatrix, CachedVector, PaddedLayout, CachedLayout, resizedata!, zero!,
                     CachedAbstractArray, CachedAbstractVector, CachedAbstractMatrix, AbstractCachedArray, AbstractCachedMatrix
+
+include("infinitearrays.jl")
+using .InfiniteArrays
+using Infinities
 
 @testset "Cache" begin
     @testset "basics" begin
@@ -431,3 +437,4 @@ import LazyArrays: CachedArray, CachedMatrix, CachedVector, PaddedLayout, Cached
     end
 end
 
+end # module

--- a/test/concattests.jl
+++ b/test/concattests.jl
@@ -1,9 +1,10 @@
+module ConcatTests
+
 using LazyArrays, FillArrays, LinearAlgebra, ArrayLayouts, Test, Base64
 using StaticArrays
 import LazyArrays: MemoryLayout, DenseColumnMajor, materialize!, call, paddeddata,
                     MulAdd, Applied, ApplyLayout, DefaultApplyStyle, sub_materialize, resizedata!,
                     CachedVector, ApplyLayout, arguments, BroadcastVector, LazyLayout
-
 
 @testset "concat" begin
     @testset "Vcat" begin
@@ -569,13 +570,13 @@ import LazyArrays: MemoryLayout, DenseColumnMajor, materialize!, call, paddeddat
     @testset "print" begin
         H = Hcat(Diagonal([1,2,3]), Zeros(3,3))
         V = Vcat(Diagonal([1,2,3]), Zeros(3,3))
-        @test stringmime("text/plain", H) == "hcat(3×3 Diagonal{$Int, Vector{$Int}}, 3×3 Zeros{Float64}):\n 1.0   ⋅    ⋅    ⋅    ⋅    ⋅ \n  ⋅   2.0   ⋅    ⋅    ⋅    ⋅ \n  ⋅    ⋅   3.0   ⋅    ⋅    ⋅ "
-        @test stringmime("text/plain", V) == "vcat(3×3 Diagonal{$Int, Vector{$Int}}, 3×3 Zeros{Float64}):\n 1.0   ⋅    ⋅ \n  ⋅   2.0   ⋅ \n  ⋅    ⋅   3.0\n  ⋅    ⋅    ⋅ \n  ⋅    ⋅    ⋅ \n  ⋅    ⋅    ⋅ "
+        @test stringmime("text/plain", H) == "hcat(3×3 $Diagonal{$Int, Vector{$Int}}, 3×3 Zeros{Float64}):\n 1.0   ⋅    ⋅    ⋅    ⋅    ⋅ \n  ⋅   2.0   ⋅    ⋅    ⋅    ⋅ \n  ⋅    ⋅   3.0   ⋅    ⋅    ⋅ "
+        @test stringmime("text/plain", V) == "vcat(3×3 $Diagonal{$Int, Vector{$Int}}, 3×3 Zeros{Float64}):\n 1.0   ⋅    ⋅ \n  ⋅   2.0   ⋅ \n  ⋅    ⋅   3.0\n  ⋅    ⋅    ⋅ \n  ⋅    ⋅    ⋅ \n  ⋅    ⋅    ⋅ "
         v = Vcat(1, Zeros(3))
         @test colsupport(v,1) == 1:1
         @test stringmime("text/plain", v) == "vcat($Int, 3-element Zeros{Float64}):\n 1.0\n  ⋅ \n  ⋅ \n  ⋅ "
         A = Vcat(Ones{Int}(1,3), Diagonal(1:3))
-        @test stringmime("text/plain", A) == "vcat(1×3 Ones{$Int}, 3×3 Diagonal{$Int, UnitRange{$Int}}):\n 1  1  1\n 1  ⋅  ⋅\n ⋅  2  ⋅\n ⋅  ⋅  3"
+        @test stringmime("text/plain", A) == "vcat(1×3 Ones{$Int}, 3×3 $Diagonal{$Int, UnitRange{$Int}}):\n 1  1  1\n 1  ⋅  ⋅\n ⋅  2  ⋅\n ⋅  ⋅  3"
     end
 
     @testset "number-vec-vcat-broadcast" begin
@@ -620,3 +621,5 @@ import LazyArrays: MemoryLayout, DenseColumnMajor, materialize!, call, paddeddat
         @test h[[1 2; 1 2],:] == Matrix(h)[[1 2; 1 2],:]
     end
 end
+
+end # module

--- a/test/lazymultests.jl
+++ b/test/lazymultests.jl
@@ -1,5 +1,8 @@
+module LazyMulTests
+
 using LazyArrays, ArrayLayouts, LinearAlgebra, FillArrays
 import LazyArrays: materialize!, MemoryLayout, triangulardata, LazyLayout, UnknownLayout, LazyMatrix, simplifiable
+using Test
 
 # used to test general matrix backends
 struct MyMatrix{T} <: LazyMatrix{T}
@@ -372,3 +375,4 @@ LinearAlgebra.factorize(A::MyLazyArray) = factorize(A.data)
     end
 end
 
+end # module

--- a/test/ldivtests.jl
+++ b/test/ldivtests.jl
@@ -1,3 +1,5 @@
+module LdivRdivTests
+
 using LazyArrays, LinearAlgebra, FillArrays, Test
 import LazyArrays: InvMatrix, ApplyBroadcastStyle, LdivStyle, Applied, LazyLayout, simplifiable
 import Base.Broadcast: materialize
@@ -162,3 +164,5 @@ end
     @test axes(R) == (axes(R,1),axes(R,2)) == axes(A)
     @test R ≈ apply(/, A, A) ≈ Eye(5)
 end
+
+end # module

--- a/test/paddedtests.jl
+++ b/test/paddedtests.jl
@@ -1,6 +1,9 @@
+module PaddedTests
+
 using LazyArrays, FillArrays, ArrayLayouts, StaticArrays, Base64, Test
 import LazyArrays: PaddedLayout, LayoutVector, MemoryLayout, paddeddata, ApplyLayout, sub_materialize, CachedVector
 import Base: setindex
+using LinearAlgebra
 
 # padded block arrays have padded data that is also padded. This is to test this
 struct PaddedPadded <: LayoutVector{Int} end
@@ -71,7 +74,7 @@ paddeddata(a::PaddedPadded) = a
 
         @testset "PaddedPadded" begin
             @test colsupport(PaddedPadded()) ≡ Base.OneTo(10)
-            @test stringmime("text/plain", PaddedPadded()) == "10-element PaddedPadded:\n 1\n 1\n 1\n 1\n 1\n 0\n 0\n 0\n 0\n 0"
+            @test stringmime("text/plain", PaddedPadded()) == "10-element $PaddedPadded:\n 1\n 1\n 1\n 1\n 1\n 0\n 0\n 0\n 0\n 0"
             @test dot(PaddedPadded(), PaddedPadded()) == 5
             @test dot(PaddedPadded(), 1:10) == dot(1:10, PaddedPadded()) == 15
 
@@ -324,3 +327,5 @@ paddeddata(a::PaddedPadded) = a
         @test norm(a) ≡ LinearAlgebra.normInf(c) ≡ LinearAlgebra.norm2(c) ≡ LinearAlgebra.norm1(c) ≡ LinearAlgebra.normp(c,2) ≡ 1.0
     end
 end
+
+end # module

--- a/test/setoptests.jl
+++ b/test/setoptests.jl
@@ -1,3 +1,5 @@
+module SetOpTests
+
 using LazyArrays, Test
 import LazyArrays: ApplyStyle, VectorSetStyle, SetStyle
 
@@ -22,4 +24,6 @@ import LazyArrays: ApplyStyle, VectorSetStyle, SetStyle
     @test 2 ∈ applied(setdiff, [1,2], Set([1.0]))
 
     @test 1 ∈ applied(intersect, [1,2], Set([1.0]), 1f0)
-end
+end # testset
+
+end # module


### PR DESCRIPTION
This makes it easier to include each test file individually to only run a subset of tests.