### PR TITLE
Let broadcasting and transposes commute

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LazyArrays"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "1.9.1"
+version = "1.10"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -247,7 +247,7 @@ resizedata!(_, _, B::AbstractVector, n) = _vec_resizedata!(B, n)
 resizedata!(_, _, B::AbstractVector, n::Integer) = _vec_resizedata!(B, n)
 
 function resizedata!(_, _, B::AbstractArray{<:Any,N}, nm::Vararg{Integer,N}) where N
-    @boundscheck checkbounds(Bool, B, nm...) || throw(ArgumentError("Cannot resize beyond size of operator"))
+    @boundscheck all(nm .≤ size(B)) || throw(ArgumentError("Cannot resize beyond size of operator"))
 
     # increase size of array if necessary
     olddata = cacheddata(B)

--- a/src/lazyapplying.jl
+++ b/src/lazyapplying.jl
@@ -328,6 +328,8 @@ MemoryLayout(::Type{Applied{Style,F,Args}}) where {Style,F,Args} =
 MemoryLayout(::Type{ApplyArray{T,N,F,Args}}) where {T,N,F,Args} =
     applylayout(F, tuple_type_memorylayouts(Args)...)
 
+arguments(::ApplyLayout{F}, A::ApplyArray{<:Any,N,F}) where {N,F} = A.args
+
 @inline Applied(A::AbstractArray) = Applied(call(A), arguments(A)...)
 
 function show(io::IO, A::Applied)

--- a/src/lazybroadcasting.jl
+++ b/src/lazybroadcasting.jl
@@ -267,7 +267,7 @@ end
 @inline __broadcastview(inds) = ()
 @inline __broadcastview(inds, a, b...) = (_broadcastview(a, inds), __broadcastview(inds, b...)...)
 
-@inline function _broadcast_sub_arguments(lay, P, V)
+@inline function _broadcast_sub_arguments(lay::BroadcastLayout, P, V)
     args = arguments(lay, P)
     __broadcastview(parentindices(V), args...)
 end
@@ -275,9 +275,9 @@ end
 @inline _broadcast_sub_arguments(lay::DualLayout{ML}, P, V::AbstractVector) where ML =
     arguments(ML(), view(_adjortrans(P), parentindices(V)[2]))
 
-@inline _broadcast_sub_arguments(lay, V) =  _broadcast_sub_arguments(lay, parent(V), V)
-@inline _broadcast_sub_arguments(V) = _broadcast_sub_arguments(MemoryLayout(V), V)
-@inline arguments(lay::BroadcastLayout, V::SubArray) = _broadcast_sub_arguments(lay, V)
+@inline _broadcast_sub_arguments(A, V) = _broadcast_sub_arguments(MemoryLayout(A), A, V)
+@inline _broadcast_sub_arguments(V) =  _broadcast_sub_arguments(parent(V), V)
+@inline arguments(lay::BroadcastLayout, V::SubArray) = _broadcast_sub_arguments(V)
 @inline call(b::BroadcastLayout, a::SubArray) = call(b, parent(a))
 
 

--- a/src/lazybroadcasting.jl
+++ b/src/lazybroadcasting.jl
@@ -300,6 +300,7 @@ arguments(b::BroadcastLayout, A::Transpose) = map(_transpose, arguments(b, paren
 # broadcasting a transpose is the same as broadcasting it to the array and transposing
 # this allows us to collapse to one broadcast.
 broadcasted(::LazyArrayStyle, op, A::Transpose{<:Any,<:BroadcastArray}) = transpose(broadcast(op, parent(A)))
+broadcasted(::LazyArrayStyle, op, A::Adjoint{<:Real,<:BroadcastArray}) = adjoint(broadcast(op, parent(A)))
 
 
 ###
@@ -415,14 +416,3 @@ permutedims(A::BroadcastArray{T}) where T = BroadcastArray{T}(A.f, map(_permuted
 _adjortrans(A::SubArray{<:Any,2, <:Any, <:Tuple{Slice,Any}}) = view(_adjortrans(parent(A)), parentindices(A)[2])
 _adjortrans(A::Adjoint) = A'
 _adjortrans(A::Transpose) = transpose(A)
-
-
-# # real broadcast can use adjoint or transpose. This keeps types simple
-# sub_materialize(::DualLayout{BroadcastLayout{typeof(real)}}, A::AbstractMatrix{<:Real}) = sub_materialize(view(_adjortrans(A), parentindices(A)[2]))'
-
-# _adjortrans(A::BroadcastArray{T,N,typeof(real)}) where {T,N} = broadcast(real, _adjortrans(A.args...))
-# # transpose and adjoint are equivalent for real
-# transpose(A::BroadcastArray{T,N,typeof(real)}) where {T,N} = _adjortrans(A)
-# adjoint(A::BroadcastArray{T,N,typeof(real)}) where {T,N} = _adjortrans(A)
-
-# broadcastlayout(::Type{typeof(real)}, ::DualLayout{ApplyLayout{typeof(hcat)}}) = DualLayout{ApplyLayout{typeof(hcat)}}()

--- a/src/lazybroadcasting.jl
+++ b/src/lazybroadcasting.jl
@@ -267,7 +267,7 @@ end
 @inline __broadcastview(inds) = ()
 @inline __broadcastview(inds, a, b...) = (_broadcastview(a, inds), __broadcastview(inds, b...)...)
 
-@inline function _broadcast_sub_arguments(lay::BroadcastLayout, P, V)
+@inline function _broadcast_sub_arguments(lay, P, V)
     args = arguments(lay, P)
     __broadcastview(parentindices(V), args...)
 end

--- a/src/lazybroadcasting.jl
+++ b/src/lazybroadcasting.jl
@@ -134,7 +134,6 @@ BroadcastStyle(::Type{<:Transpose{<:Any,<:LazyVector}}) = LazyArrayStyle{2}()
 BroadcastStyle(::Type{<:Adjoint{<:Any,<:LazyMatrix}}) = LazyArrayStyle{2}()
 BroadcastStyle(::Type{<:Transpose{<:Any,<:LazyMatrix}}) = LazyArrayStyle{2}()
 BroadcastStyle(::Type{<:SubArray{<:Any,1,<:LazyMatrix,<:Tuple{Slice,Any}}}) = LazyArrayStyle{1}()
-BroadcastStyle(::Type{<:SubArray{<:Any,1,<:LazyVector}}) = LazyArrayStyle{1}()
 BroadcastStyle(L::LazyArrayStyle{N}, ::StructuredMatrixStyle)  where N = L
 
 
@@ -417,3 +416,5 @@ _adjortrans(A::Transpose) = transpose(A)
 
 
 _adjortrans(A::BroadcastArray{T,N,typeof(real)}) where {T,N} = broadcast(real, _adjortrans(A.args...))
+transpose(A::BroadcastArray{T,N,typeof(real)}) where {T,N} = broadcast(real, transpose(A.args...))
+adjoint(A::BroadcastArray{T,N,typeof(real)}) where {T,N} = broadcast(real, adjoint(A.args...))

--- a/src/lazybroadcasting.jl
+++ b/src/lazybroadcasting.jl
@@ -416,5 +416,6 @@ _adjortrans(A::Transpose) = transpose(A)
 
 
 _adjortrans(A::BroadcastArray{T,N,typeof(real)}) where {T,N} = broadcast(real, _adjortrans(A.args...))
-transpose(A::BroadcastArray{T,N,typeof(real)}) where {T,N} = broadcast(real, transpose(A.args...))
-adjoint(A::BroadcastArray{T,N,typeof(real)}) where {T,N} = broadcast(real, adjoint(A.args...))
+# transpose and adjoint are equivalent for real
+transpose(A::BroadcastArray{T,N,typeof(real)}) where {T,N} = _adjortrans(A)
+adjoint(A::BroadcastArray{T,N,typeof(real)}) where {T,N} = _adjortrans(A)

--- a/src/lazybroadcasting.jl
+++ b/src/lazybroadcasting.jl
@@ -297,6 +297,10 @@ _transpose(a::Ref) = a
 arguments(b::BroadcastLayout, A::Adjoint) = map(_adjoint, arguments(b, parent(A)))
 arguments(b::BroadcastLayout, A::Transpose) = map(_transpose, arguments(b, parent(A)))
 
+# broadcasting a transpose is the same as broadcasting it to the array and transposing
+# this allows us to collapse to one broadcast.
+broadcasted(::LazyArrayStyle, op, A::Transpose{<:Any,<:BroadcastArray}) = transpose(broadcast(op, parent(A)))
+
 
 ###
 # Show

--- a/src/lazybroadcasting.jl
+++ b/src/lazybroadcasting.jl
@@ -277,6 +277,7 @@ end
     arguments(ML(), view(_adjortrans(P), parentindices(V)[2]))
 
 @inline _broadcast_sub_arguments(lay, V) =  _broadcast_sub_arguments(lay, parent(V), V)
+@inline _broadcast_sub_arguments(V) = _broadcast_sub_arguments(MemoryLayout(V), V)
 @inline arguments(lay::BroadcastLayout, V::SubArray) = _broadcast_sub_arguments(lay, V)
 @inline call(b::BroadcastLayout, a::SubArray) = call(b, parent(a))
 

--- a/src/lazybroadcasting.jl
+++ b/src/lazybroadcasting.jl
@@ -94,7 +94,7 @@ last(A::BroadcastArray) = A.f(last.(A.args)...)
 
 converteltype(::Type{T}, A::AbstractArray) where T = convert(AbstractArray{T}, A)
 converteltype(::Type{T}, A) where T = convert(T, A)
-sub_materialize(::BroadcastLayout, A) = converteltype(eltype(A), materialize(_broadcasted(A)))
+sub_materialize(::BroadcastLayout, A) = converteltype(eltype(A), sub_materialize(_broadcasted(A)))
 
 copy(bc::Broadcasted{<:LazyArrayStyle}) = BroadcastArray(bc)
 
@@ -407,15 +407,18 @@ permutedims(A::BroadcastArray{T}) where T = BroadcastArray{T}(A.f, map(_permuted
 
 @inline broadcastlayout(::Type{F}, ::DualLayout) where F = DualLayout{BroadcastLayout{F}}()
 
-# real broadcast can use adjoint or transpose. This keeps types simple
-sub_materialize(::DualLayout{BroadcastLayout{typeof(real)}}, A::AbstractMatrix{<:Real}) = sub_materialize(view(_adjortrans(A), parentindices(A)[2]))'
 
 _adjortrans(A::SubArray{<:Any,2, <:Any, <:Tuple{Slice,Any}}) = view(_adjortrans(parent(A)), parentindices(A)[2])
 _adjortrans(A::Adjoint) = A'
 _adjortrans(A::Transpose) = transpose(A)
 
 
-_adjortrans(A::BroadcastArray{T,N,typeof(real)}) where {T,N} = broadcast(real, _adjortrans(A.args...))
-# transpose and adjoint are equivalent for real
-transpose(A::BroadcastArray{T,N,typeof(real)}) where {T,N} = _adjortrans(A)
-adjoint(A::BroadcastArray{T,N,typeof(real)}) where {T,N} = _adjortrans(A)
+# # real broadcast can use adjoint or transpose. This keeps types simple
+# sub_materialize(::DualLayout{BroadcastLayout{typeof(real)}}, A::AbstractMatrix{<:Real}) = sub_materialize(view(_adjortrans(A), parentindices(A)[2]))'
+
+# _adjortrans(A::BroadcastArray{T,N,typeof(real)}) where {T,N} = broadcast(real, _adjortrans(A.args...))
+# # transpose and adjoint are equivalent for real
+# transpose(A::BroadcastArray{T,N,typeof(real)}) where {T,N} = _adjortrans(A)
+# adjoint(A::BroadcastArray{T,N,typeof(real)}) where {T,N} = _adjortrans(A)
+
+# broadcastlayout(::Type{typeof(real)}, ::DualLayout{ApplyLayout{typeof(hcat)}}) = DualLayout{ApplyLayout{typeof(hcat)}}()

--- a/src/lazybroadcasting.jl
+++ b/src/lazybroadcasting.jl
@@ -302,6 +302,11 @@ arguments(b::BroadcastLayout, A::Transpose) = map(_transpose, arguments(b, paren
 broadcasted(::LazyArrayStyle, op, A::Transpose{<:Any,<:BroadcastArray}) = transpose(broadcast(op, parent(A)))
 broadcasted(::LazyArrayStyle, op, A::Adjoint{<:Real,<:BroadcastArray}) = adjoint(broadcast(op, parent(A)))
 
+# ensure we benefit from fast linear indexing
+getindex(A::Transpose{<:Any,<:BroadcastVector}, k::AbstractVector) = parent(A)[k]
+getindex(A::Adjoint{<:Real,<:BroadcastVector}, k::AbstractVector) = parent(A)[k]
+getindex(A::Adjoint{<:Any,<:BroadcastVector}, k::AbstractVector) = conj.(parent(A))[k]
+
 
 ###
 # Show

--- a/src/lazyconcat.jl
+++ b/src/lazyconcat.jl
@@ -504,6 +504,7 @@ _flatten_nums(args::Tuple, bc::Tuple) = (bc[1], _flatten_nums(tail(args), tail(b
 _flatten_nums(args::Tuple{Number, Vararg{Any}}, bc::Tuple{AbstractArray, Vararg{Any}}) = (Fill(bc[1],1), _flatten_nums(tail(args), tail(bc))...)
 
 broadcasted(::LazyArrayStyle, op, A::Vcat) = Vcat(_flatten_nums(A.args, broadcast(x -> broadcast(op, x), A.args))...)
+broadcasted(::LazyArrayStyle, op, A::Transpose{<:Any,<:Vcat}) = transpose(broadcast(op, parent(A)))
 
 
 for Cat in (:Vcat, :Hcat)

--- a/src/lazyconcat.jl
+++ b/src/lazyconcat.jl
@@ -505,6 +505,7 @@ _flatten_nums(args::Tuple{Number, Vararg{Any}}, bc::Tuple{AbstractArray, Vararg{
 
 broadcasted(::LazyArrayStyle, op, A::Vcat) = Vcat(_flatten_nums(A.args, broadcast(x -> broadcast(op, x), A.args))...)
 broadcasted(::LazyArrayStyle, op, A::Transpose{<:Any,<:Vcat}) = transpose(broadcast(op, parent(A)))
+broadcasted(::LazyArrayStyle, op, A::Adjoint{<:Real,<:Vcat}) = broadcast(op, parent(A))'
 
 
 for Cat in (:Vcat, :Hcat)

--- a/src/lazyconcat.jl
+++ b/src/lazyconcat.jl
@@ -947,10 +947,10 @@ _searchsortedlast(a, x) = searchsortedlast(a, x)
 _searchsortedlast(a::Number, x) = 0 + (x ≥ a)
 
 searchsortedfirst(f::Vcat{<:Any,1}, x) =
-    searchsortedfirst_recursive(0, x, arguments(f)...)
+    searchsortedfirst_recursive(0, x, arguments(vcat, f)...)
 
 searchsortedlast(f::Vcat{<:Any,1}, x) =
-    searchsortedlast_recursive(length(f), x, reverse(arguments(f))...)
+    searchsortedlast_recursive(length(f), x, reverse(arguments(vcat, f))...)
 
 @inline searchsortedfirst_recursive(n, x) = n + 1
 

--- a/test/broadcasttests.jl
+++ b/test/broadcasttests.jl
@@ -1,6 +1,12 @@
+module BroadcastTests
+
 using LazyArrays, ArrayLayouts, LinearAlgebra, FillArrays, StaticArrays, Tracker, Base64, Test
 import LazyArrays: BroadcastLayout, arguments, LazyArrayStyle, sub_materialize
 import Base: broadcasted
+
+include("infinitearrays.jl")
+using .InfiniteArrays
+using Infinities
 
 @testset "Broadcasting" begin
     @testset "BroadcastArray" begin
@@ -396,3 +402,5 @@ import Base: broadcasted
         @test a[:,1:3] isa Adjoint{Int,Vector{Int}}
     end
 end
+
+end #module

--- a/test/broadcasttests.jl
+++ b/test/broadcasttests.jl
@@ -401,6 +401,19 @@ using Infinities
         @test a[:,1:3] == (1:3)'
         @test a[:,1:3] isa Adjoint{Int,Vector{Int}}
     end
+
+    @testset "broadcast with adjtrans" begin
+        a = BroadcastArray(real, ((1:5) .+ im))
+        b = BroadcastArray(exp, ((1:5) .+ im))
+        @test exp.(transpose(a)) isa Transpose{<:Any,<:BroadcastVector}
+        @test exp.(a') isa Adjoint{<:Any,<:BroadcastVector}
+        @test exp.(a') == exp.(transpose(a)) == exp.(a)'
+
+        @test exp.(transpose(b)) isa Transpose{<:Any,<:BroadcastVector}
+        @test exp.(b') isa BroadcastMatrix
+        @test exp.(transpose(b)) == transpose(exp.(b))
+        @test exp.(b') == exp.(b)'
+    end
 end
 
 end #module

--- a/test/broadcasttests.jl
+++ b/test/broadcasttests.jl
@@ -414,6 +414,14 @@ using Infinities
         @test exp.(transpose(b)) == transpose(exp.(b))
         @test exp.(b') == exp.(b)'
     end
+
+    @testset "linear indexing" begin
+        a = BroadcastArray(real, ((1:5) .+ im))
+        b = BroadcastArray(exp, ((1:5) .+ im))
+        @test transpose(a)[1:5] == a'[1:5] == 1:5
+        @test transpose(b)[1:5] == exp.((1:5) .+ im)
+        @test b'[1:5] == exp.((1:5) .- im)
+    end
 end
 
 end #module

--- a/test/concattests.jl
+++ b/test/concattests.jl
@@ -620,6 +620,20 @@ import LazyArrays: MemoryLayout, DenseColumnMajor, materialize!, call, paddeddat
         @test MemoryLayout(view(h, [1 2; 1 2], 1)) isa LazyLayout
         @test h[[1 2; 1 2],:] == Matrix(h)[[1 2; 1 2],:]
     end
+
+    @testset "transpose" begin
+        a = Vcat(2, Ones(5))
+        b = Vcat(2, Ones(5)) .+ im
+
+        @test exp.(transpose(a)) isa Transpose{<:Any,<:Vcat}
+        @test exp.(a') isa Adjoint{<:Any,<:Vcat}
+        @test exp.(transpose(a)) == exp.(a') == exp.(a)'
+
+        @test exp.(transpose(b)) isa Transpose{<:Any,<:Vcat}
+        @test exp.(b') isa BroadcastArray
+        @test exp.(transpose(b)) == transpose(exp.(b))
+        @test exp.(b') == exp.(b)'
+    end
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -452,9 +452,9 @@ end
     @test BroadcastArray(bc) == BroadcastMatrix(bc) == BroadcastMatrix{Float64,typeof(exp),typeof(bc.args)}(bc) ==
         M == BroadcastMatrix(BroadcastMatrix(bc)) == BroadcastMatrix(exp,[1 2; 3 4]) == exp.([1 2; 3 4])
 
-    @test exp.(v') isa BroadcastMatrix
+    @test exp.(v') isa Adjoint{<:Any,<:BroadcastVector}
     @test exp.(transpose(v)) isa Transpose{<:Any,<:BroadcastVector}
-    @test exp.(M') isa BroadcastMatrix
+    @test exp.(M') isa Adjoint{<:Any,<:BroadcastMatrix}
     @test exp.(transpose(M)) isa Transpose{<:Any,<:BroadcastMatrix}
 
     bc = BroadcastArray(broadcasted(+, 1:10, broadcasted(sin, 1:10)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,10 +48,6 @@ end
     end
 end
 
-include("infinitearrays.jl")
-using .InfiniteArrays
-using Infinities
-
 include("applytests.jl")
 include("multests.jl")
 include("ldivtests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -453,9 +453,9 @@ end
         M == BroadcastMatrix(BroadcastMatrix(bc)) == BroadcastMatrix(exp,[1 2; 3 4]) == exp.([1 2; 3 4])
 
     @test exp.(v') isa BroadcastMatrix
-    @test exp.(transpose(v)) isa BroadcastMatrix
+    @test exp.(transpose(v)) isa Transpose{<:Any,<:BroadcastVector}
     @test exp.(M') isa BroadcastMatrix
-    @test exp.(transpose(M)) isa BroadcastMatrix
+    @test exp.(transpose(M)) isa Transpose{<:Any,<:BroadcastMatrix}
 
     bc = BroadcastArray(broadcasted(+, 1:10, broadcasted(sin, 1:10)))
     @test bc[1:10] == (1:10) .+ sin.(1:10)


### PR DESCRIPTION
Consider `exp.(transpose(exp.(1:∞)))`. This will simplify to `transpose(exp.(exp.(1:∞))` and thereby enable much faster construction.

This also allows faster linear indexing with lazy transposes/adjoints.