### PR TITLE
Fix error message for `@~` when multiple arguments are captured

### DIFF
--- a/src/lazymacro.jl
+++ b/src/lazymacro.jl
@@ -86,7 +86,7 @@ function checkex(ex)
         end
     end
     if @capture(ex, (arg_,rest__) )
-        throw(ArgumentError("@~ is capturing more than one expression, try $name($arg) with brackets"))
+        throw(ArgumentError("@~ is capturing more than one expression, try capturing \"$arg\" with brackets"))
     end
     ex
 end

--- a/test/macrotests.jl
+++ b/test/macrotests.jl
@@ -103,4 +103,8 @@ end
     @test copy(@views @~ exp.(A[1:2, 1:2])) == exp.(A[1:2, 1:2])
 end
 
+@testset "error capturing" begin
+    @test_throws "ArgumentError: @~ is capturing more than one expression, try capturing \"u - v\" with brackets" @macroexpand @~ u - v, 2
+end
+
 end  # module


### PR DESCRIPTION
Currently, expressions like `@~ expr1, expr2` give an error:

```julia
julia> @~ u - v, 2
ERROR: LoadError: UndefVarError: `name` not defined
Stacktrace:
 [1] checkex(ex::Expr)
   @ LazyArrays C:\Users\User\.julia\packages\LazyArrays\nyS8r\src\lazymacro.jl:89
 [2] var"@~"(__source__::LineNumberNode, __module__::Module, ex::Any)
   @ LazyArrays C:\Users\User\.julia\packages\LazyArrays\nyS8r\src\lazymacro.jl:112
in expression starting at REPL[14]:1
```

This change fixes it so that you instead see

```julia
julia> @~ u - v, 2
ERROR: LoadError: ArgumentError: @~ is capturing more than one expression, try capturing "u - v" with brackets
Stacktrace:
 [1] checkex(ex::Expr)
   @ LazyArrays c:\Users\User\.julia\dev\LazyArrays.jl\src\lazymacro.jl:89
 [2] var"@~"(__source__::LineNumberNode, __module__::Module, ex::Any)
   @ LazyArrays c:\Users\User\.julia\dev\LazyArrays.jl\src\lazymacro.jl:112
in expression starting at REPL[46]:1
```

I'm not sure what the previous `name` function did, but hopefully that captures the intention still. I thought it was supposed to be `nameof` but that doesn't work.