### PR TITLE
Better Ldiv for lazy banded and fill! for views of CachedVector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LazyArrays"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "2.0.2"
+version = "2.0.3"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/ext/LazyArraysBandedMatricesExt.jl
+++ b/ext/LazyArraysBandedMatricesExt.jl
@@ -578,7 +578,8 @@ simplifiable(::Mul{<:AbstractInvLayout, <:BandedLazyLayouts}) = Val(false)
 copy(M::Mul{<:AbstractInvLayout, <:BandedLazyLayouts}) = simplify(M)
 
 
-copy(L::Ldiv{<:BandedLazyLayouts, <:BandedLazyLayouts}) = lazymaterialize(\, L.A, L.B)
+copy(L::Ldiv{<:BandedLazyLayouts}) = lazymaterialize(\, L.A, L.B)
+copy(L::Ldiv{<:BandedLazyLayouts, Blay}) where Blay<:Union{AbstractStridedLayout,PaddedColumns} = copy(Ldiv{UnknownLayout,Blay}(L.A, L.B))
 
 # TODO: this is type piracy
 function colsupport(lay::ApplyLayout{typeof(\)}, L, j)

--- a/ext/LazyArraysBandedMatricesExt.jl
+++ b/ext/LazyArraysBandedMatricesExt.jl
@@ -623,6 +623,7 @@ simplifiable(::Mul{<:BroadcastBandedLayout, <:Union{AbstractPaddedLayout,Abstrac
 
 copy(L::Ldiv{ApplyBandedLayout{typeof(*)}, Lay}) where Lay = copy(Ldiv{ApplyLayout{typeof(*)},Lay}(L.A, L.B))
 copy(L::Ldiv{ApplyBandedLayout{typeof(*)}, Lay}) where Lay<:BroadcastBandedLayout = copy(Ldiv{ApplyLayout{typeof(*)},Lay}(L.A, L.B))
+copy(L::Ldiv{ApplyBandedLayout{typeof(*)}, Lay}) where Lay<:Union{PaddedColumns,AbstractStridedLayout} = copy(Ldiv{ApplyLayout{typeof(*)},Lay}(L.A, L.B))
 _inv(::BandedLazyLayouts, _, A) = ApplyArray(inv, A)
 
 ####

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -412,6 +412,22 @@ function fill!(a::CachedArray, x)
     a
 end
 
+function fill!(a::SubArray{<:Any,1,<:CachedVector}, x)
+    p = parent(a)
+    kr = parentindices(a)[1]
+    if !isempty(kr)
+        N = maximum(kr)
+        if isfinite(N)
+            resizedata!(p, N)
+            fill!(view(p.data, kr), x)
+        else    
+            fill!(view(p.data, kr ∩ OneTo(p.datasize[1])), x)
+            fill!(view(p.array, kr), x)
+        end
+    end
+    a
+end
+
 function rmul!(a::CachedArray, x::Number)
     rmul!(a.data, x)
     rmul!(a.array, x)

--- a/test/bandedtests.jl
+++ b/test/bandedtests.jl
@@ -832,6 +832,20 @@ LinearAlgebra.lmul!(β::Number, A::PseudoBandedMatrix) = (lmul!(β, A.data); A)
         @test MemoryLayout(UpperTriangular(A)) isa TriangularLayout{'U', 'N', LazyBandedLayout}
         @test MemoryLayout(LowerTriangular(A)) isa TriangularLayout{'L', 'N', LazyBandedLayout}
     end
+
+    @testset "lazy banded Ldiv" begin
+        n = 10
+        A = BroadcastArray(*, 3, brand(n,n,2,1))
+        b = randn(n)
+        @test A \ b ≈ Matrix(A) \ b
+        @test A \ b isa Vector
+        b = Vcat(randn(3), Zeros(7))
+        @test inv(A) * b == A \ b
+        @test A\b isa Vector
+
+        @test A \ A ≈ I
+        @test A \ A isa ApplyArray
+    end
 end
 
 end # module

--- a/test/cachetests.jl
+++ b/test/cachetests.jl
@@ -385,7 +385,7 @@ using Infinities
 
     @testset "getindex and data structure" begin
         A = Matrix(1.0I[1:100,1:100])
-        A[2,1] = 3. 
+        A[2,1] = 3.
         Ac = cache(sparse(A))
         @test Ac isa AbstractCachedArray
         @test Ac isa AbstractCachedMatrix
@@ -442,7 +442,19 @@ using Infinities
         Q = qr(randn(5,5)).Q
         C = cache(Q);
         @test C[1:5,1:5] == Q[1:5,1:5]
-        @test length(C) == 25        
+        @test length(C) == 25
+    end
+
+    @testset "fill! views" begin
+        a = CachedArray(Zeros{Float64}(100));
+        view(a, 2:2:5) .= 2;
+        @test a.datasize == (4,)
+        @test a[1:5] == [0,2,0,2,0]
+
+        a = CachedArray(Zeros{Float64}(∞));
+        a[4] = 2;
+        view(a, 2:2:∞) .= 0.0;
+        @test a[1:5] == zeros(5)
     end
 end
 

--- a/test/cachetests.jl
+++ b/test/cachetests.jl
@@ -446,14 +446,14 @@ using Infinities
     end
 
     @testset "fill! views" begin
-        a = CachedArray(Zeros{Float64}(100));
+        a = CachedArray(Zeros(100));
         view(a, 2:2:5) .= 2;
         @test a.datasize == (4,)
         @test a[1:5] == [0,2,0,2,0]
 
-        a = CachedArray(Zeros{Float64}(∞));
+        a = CachedArray(Zeros(ℵ₀));
         a[4] = 2;
-        view(a, 2:2:∞) .= 0.0;
+        view(a, 2:ℵ₀) .= 0.0;
         @test a[1:5] == zeros(5)
     end
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaApproximation/ClassicalOrthogonalPolynomials.jl/issues/178

With this:
```julia
julia> U \ diff(U)
\(ℵ₀×ℵ₀ BandedMatrix{Float64} with bandwidths (0, 2) with data vcat(((-).((Float64) ./ (ℵ₀-element InfiniteArrays.InfStepRange{Float64, Float64} with indices OneToInf()) with indices OneToInf()) with indices OneToInf())' with indices Base.OneTo(1)×OneToInf(), 1×ℵ₀ Zeros{Float64, 2, Tuple{Base.OneTo{Int64}, InfiniteArrays.OneToInf{Int64}}} with indices Base.OneTo(1)×OneToInf(), ((Float64) ./ (ℵ₀-element InfiniteArrays.InfStepRange{Float64, Float64} with indices OneToInf()) with indices OneToInf())' with indices Base.OneTo(1)×OneToInf()) with indices Base.OneTo(3)×OneToInf() with indices OneToInf()×OneToInf(), ℵ₀×ℵ₀ BandedMatrix{Float64} with bandwidths (-1, 1) with data 1×ℵ₀ Fill{Float64, 2, Tuple{Base.OneTo{Int64}, InfiniteArrays.OneToInf{Int64}}} with indices Base.OneTo(1)×OneToInf() with indices OneToInf()×OneToInf()) with indices OneToInf()×OneToInf():
  ⋅   2.0  0.0  2.0  0.0   2.0   0.0   2.0   0.0   2.0   0.0   2.0   0.0  …  
  ⋅    ⋅   4.0  0.0  4.0   0.0   4.0   0.0   4.0   0.0   4.0   0.0   4.0     
  ⋅    ⋅    ⋅   6.0  0.0   6.0   0.0   6.0   0.0   6.0   0.0   6.0   0.0     
  ⋅    ⋅    ⋅    ⋅   8.0   0.0   8.0   0.0   8.0   0.0   8.0   0.0   8.0     
  ⋅    ⋅    ⋅    ⋅    ⋅   10.0   0.0  10.0   0.0  10.0   0.0  10.0   0.0     
  ⋅    ⋅    ⋅    ⋅    ⋅     ⋅   12.0   0.0  12.0   0.0  12.0   0.0  12.0  …  
  ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅   14.0   0.0  14.0   0.0  14.0   0.0     
  ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅   16.0   0.0  16.0   0.0  16.0     
  ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅   18.0   0.0  18.0   0.0     
 ⋮                         ⋮                             ⋮                ⋱  
```
