### PR TITLE
Change signature of `materialize!` to fix regression on Windows

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LazyArrays"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "2.1.6"
+version = "2.1.7"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/ext/LazyArraysBandedMatricesExt.jl
+++ b/ext/LazyArraysBandedMatricesExt.jl
@@ -155,7 +155,7 @@ function similar(M::MulAdd{<:DualLayout{<:PaddedRows}, <:BandedLayouts}, ::Type{
     trans(Vcat(Vector{T}(undef, n), Zeros{T}(size(A,1)-n)))
 end
 
-function materialize!(M::MatMulVecAdd{<:BandedLayouts,<:Union{PaddedColumns,PaddedLayout},<:Union{PaddedColumns,PaddedLayout}})
+function materialize!(M::MatMulVecAdd{<:BandedLayouts,<:AbstractPaddedLayout,<:AbstractPaddedLayout})
     α,A,x,β,y = M.α,M.A,M.B,M.β,M.C
     length(y) == size(A,1) || throw(DimensionMismatch())
     length(x) == size(A,2) || throw(DimensionMismatch())


### PR DESCRIPTION
As discussed here https://github.com/JuliaApproximation/SemiclassicalOrthogonalPolynomials.jl/pull/111, this fixes the weird inlining bug/regression on Windows by changing the signature of `materialize!`. Don't know if this is the best solution ideally, but it seems to work. Tests pass locally but let's see what the downstream CI says.

Don't really know the best way to a test of this regression to avoid this happening again.. I guess just checking that the Windows CI times are comparable to the other OSs?