### PR TITLE
Revert "Add (row/col)support for inv(Triangular)"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LazyArrays"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "2.1.7"
+version = "2.1.8"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/linalg/inv.jl
+++ b/src/linalg/inv.jl
@@ -185,16 +185,3 @@ getindex(L::ApplyMatrix{<:Any,typeof(/)}, k::Integer, j::Integer) = L[k,:][j]
 
 
 inv_layout(::LazyLayouts, _, A) = ApplyArray(inv, A)
-
-### 
-# row/colsupport triangular
-###
-function colsupport(lay::AbstractInvLayout{<:TriangularLayout}, A, j)
-    B, = arguments(lay, A)
-    return colsupport(B, j)
-end 
-
-function rowsupport(lay::AbstractInvLayout{<:TriangularLayout}, A, k)
-    B, = arguments(lay, A)
-    return rowsupport(B, k)
-end

--- a/test/ldivtests.jl
+++ b/test/ldivtests.jl
@@ -181,20 +181,4 @@ end
     @test Z \ Y ≈ [-2.0 1.0; 1.5 -0.5]
 end
 
-@testset "Issue #329" begin
-    for op in (UpperTriangular, UnitUpperTriangular)
-        A = UpperTriangular(ApplyArray(inv, rand(5, 5)))
-        B = inv(A)
-        @test colsupport.(Ref(B), 1:5) == Base.OneTo.(1:5)
-        @test rowsupport.(Ref(B), 1:5) == range.(1:5, 5)
-    end 
-
-    for op in (LowerTriangular, UnitLowerTriangular)
-        A = LowerTriangular(ApplyArray(inv, rand(15, 15)))
-        B = inv(A)
-        @test colsupport.(Ref(B), 1:15) == range.(1:15, 15)
-        @test rowsupport.(Ref(B), 1:15) == Base.OneTo.(1:15)
-    end
-end
-
 end # module


### PR DESCRIPTION
Reverts https://github.com/JuliaArrays/LazyArrays.jl/pull/334. See https://github.com/JuliaApproximation/SemiclassicalOrthogonalPolynomials.jl/pull/111.

Hopefully this method can be introduced once again eventually, but for now can we remove it?