### PR TITLE
Ignore versioned manifest files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 deps/deps.jl
 .DS_Store
 Manifest.toml
+Manifest-v*.*.toml
 statprof/*


### PR DESCRIPTION
Julia v1.11 introduces the ability to create manifest files for different julia versions, and we may ignore these as well.