### PR TITLE
Avoid depending on `LazyArraysBandedMatricesExt` from within `LazyArraysBlockBandedMatricesExt`

### DIFF
--- a/src/LazyArrays.jl
+++ b/src/LazyArrays.jl
@@ -71,6 +71,12 @@ map(::typeof(length), A::BroadcastVector{<:Vcat,Type{Vcat}}) = broadcast(+,map.(
 broadcasted(::LazyArrayStyle{1}, ::typeof(length), A::BroadcastVector{OneTo{Int},Type{OneTo}}) = A.args[1]
 broadcasted(::LazyArrayStyle{1}, ::typeof(length), A::BroadcastVector{<:Fill,Type{Fill},<:NTuple{2,Any}}) = A.args[2]
 
+# types for use by extensions
+function _mulbanded_copyto! end
+
+abstract type AbstractLazyBandedLayout <: AbstractBandedLayout end
+struct LazyBandedLayout <: AbstractLazyBandedLayout end
+
 if !isdefined(Base, :get_extension)
     include("../ext/LazyArraysStaticArraysExt.jl")
     include("../ext/LazyArraysBandedMatricesExt.jl")


### PR DESCRIPTION
LazyArrays reasonably assumes that an extension w/ triggers `{B,C}` to can depend on an extension w/ triggers `{A,C}` - as long as B depends on A.

Unfortunately as detailed in https://github.com/JuliaLang/julia/issues/55557, Julia's extension loading does not actually guarantee that. Extension loading is purely trigger-based, so if `C` is the loaded after `{A,B}` then both of these extensions will trigger "simultaneously" and they will be loaded in an indeterminate order. That can mean that the first extension loads after the second, even though it expected to depend on it.

That behavior is arguably a bug and is likely to be improved in a future version of Julia, but for now this works around the problem by removing the inter-extension dependency.