### PR TITLE
Remove backwards compatibility package extension logic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,13 @@
 name = "LazyArrays"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "2.2.1"
+version = "2.2.2"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
-BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
-BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [weakdeps]
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"

--- a/src/LazyArrays.jl
+++ b/src/LazyArrays.jl
@@ -77,11 +77,4 @@ function _mulbanded_copyto! end
 abstract type AbstractLazyBandedLayout <: AbstractBandedLayout end
 struct LazyBandedLayout <: AbstractLazyBandedLayout end
 
-if !isdefined(Base, :get_extension)
-    include("../ext/LazyArraysStaticArraysExt.jl")
-    include("../ext/LazyArraysBandedMatricesExt.jl")
-    include("../ext/LazyArraysBlockArraysExt.jl")
-    include("../ext/LazyArraysBlockBandedMatricesExt.jl")
-end
-
 end # module


### PR DESCRIPTION
Some weakdeps were listed as deps so that package extensions could be loaded in older Julia versions, which doesn't seem necessary now since LazyArrays.jl requires Julia 1.10. See also https://github.com/JuliaArrays/BlockArrays.jl/pull/431.