### PR TITLE
Fix incorrectly typed method for `_vec_mul_arguments`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LazyArrays"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "2.2.2"
+version = "2.2.3"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/linalg/mul.jl
+++ b/src/linalg/mul.jl
@@ -236,7 +236,7 @@ _vec_mul_view(a...) = view(a...)
 _vec_mul_view(a::AbstractVector, kr, ::Colon) = view(a, kr)
 
 # this is a vector view of a MulVector
-function _vec_mul_arguments(args, (kr,))
+function _vec_mul_arguments(args, (kr,)::Tuple{Any})
     kjr = intersect.(_mul_args_rows(kr, args...), _mul_args_cols(Base.OneTo(1), reverse(args)...))
     _vec_mul_view.(args, (kr, kjr...), (kjr..., :))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -460,6 +460,9 @@ end
     @test bc.args[2] == 3
 end
 
+@testset "_vec_mul_arguments method" begin
+    @test_throws "MethodError: no method matching _vec_mul_arguments"  LazyArrays._vec_mul_arguments(2, [])
+end
 
 include("blocktests.jl")
 include("bandedtests.jl")


### PR DESCRIPTION
I noticed that this method is implicitly assuming that the argument is a `::Tuple{Any}` but it will actually accept any argument, i.e. the method is `_vec_mul_arguments(::Any, ::Any)` when it should be `_vec_mul_arguments(::Any, ::Tuple{Any})`. For example, on master,
```julia-repl
julia> LazyArrays._vec_mul_arguments(2, [])
ERROR: BoundsError: attempt to access 0-element Vector{Any} at index [1]
Stacktrace:
 [1] throw_boundserror(A::Vector{Any}, I::Tuple{Int64})
   @ Base .\essentials.jl:14
 [2] getindex
   @ .\essentials.jl:916 [inlined]
 [3] indexed_iterate (repeats 2 times)
   @ .\tuple.jl:160 [inlined]
 [4] _vec_mul_arguments(args::Int64, ::Vector{Any})
   @ LazyArrays C:\Users\djv23\.julia\packages\LazyArrays\zl2b5\src\linalg\mul.jl:240
 [5] top-level scope
   @ REPL[29]:1
```

I don't have the best test since the bug I encountered with this is buried in some other code (@dlfivefifty it came up when using `CircleCoordinate` which failed to match the correct method on Line 252 since `CircleCoordinate` wasn't a number and so it went to this most generic method).

Hopefully nothing downstream is relying on this behaviour somehow