### PR TITLE
Skip Aqua stale deps check in downstream tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,8 +5,10 @@ import LazyArrays: CachedArray, colsupport, rowsupport, LazyArrayStyle, broadcas
 import ArrayLayouts: OnesLayout
 
 using Aqua
+downstream_test = "--downstream_integration_test" in ARGS
 @testset "Project quality" begin
-    Aqua.test_all(LazyArrays, ambiguities=false, piracies=false)
+    Aqua.test_all(LazyArrays, ambiguities=false, piracies=false,
+        stale_deps=!downstream_test)
 end
 
 @testset "Lazy MemoryLayout" begin


### PR DESCRIPTION
This will allow other packages to be installed in downstream tests that might be needed to test package extensions.