### PR TITLE
Include the infinitearrays test helper only once

### DIFF
--- a/test/broadcasttests.jl
+++ b/test/broadcasttests.jl
@@ -4,8 +4,7 @@ using LazyArrays, ArrayLayouts, LinearAlgebra, FillArrays, StaticArrays, Tracker
 import LazyArrays: BroadcastLayout, arguments, LazyArrayStyle, sub_materialize
 import Base: broadcasted
 
-include("infinitearrays.jl")
-using .InfiniteArrays
+using ..InfiniteArrays
 using Infinities
 
 @testset "Broadcasting" begin

--- a/test/cachetests.jl
+++ b/test/cachetests.jl
@@ -6,8 +6,7 @@ import LazyArrays: CachedArray, CachedMatrix, CachedVector, PaddedLayout, Cached
                     CachedAbstractArray, CachedAbstractVector, CachedAbstractMatrix, AbstractCachedArray, AbstractCachedMatrix,
                     PaddedColumns
 
-include("infinitearrays.jl")
-using .InfiniteArrays
+using ..InfiniteArrays
 using .InfiniteArrays: OneToInf
 using Infinities
 

--- a/test/infinitearrays.jl
+++ b/test/infinitearrays.jl
@@ -24,12 +24,6 @@ module InfiniteArrays
     Base.axes(r::OneToInf) = (r,)
     Base.first(r::OneToInf{T}) where {T} = oneunit(T)
 
-    if VERSION < v"1.11-"
-        Base.oneto(::InfiniteCardinal{0}) = OneToInf()
-    else
-        Base.unchecked_oneto(::InfiniteCardinal{0}) = OneToInf()
-    end
-
     Base.axes(::AbstractInfUnitRange) = (OneToInf(),)
 
     struct InfUnitRange{T<:Real} <: AbstractInfUnitRange{T}

--- a/test/infinitearrays.jl
+++ b/test/infinitearrays.jl
@@ -24,6 +24,12 @@ module InfiniteArrays
     Base.axes(r::OneToInf) = (r,)
     Base.first(r::OneToInf{T}) where {T} = oneunit(T)
 
+    if VERSION < v"1.11-"
+        Base.oneto(::InfiniteCardinal{0}) = OneToInf()
+    else
+        Base.unchecked_oneto(::InfiniteCardinal{0}) = OneToInf()
+    end
+
     Base.axes(::AbstractInfUnitRange) = (OneToInf(),)
 
     struct InfUnitRange{T<:Real} <: AbstractInfUnitRange{T}

--- a/test/paddedtests.jl
+++ b/test/paddedtests.jl
@@ -7,9 +7,6 @@ import ArrayLayouts: OnesLayout
 import Base: setindex
 using LinearAlgebra
 
-include("infinitearrays.jl")
-using .InfiniteArrays: OneToInf
-
 # padded block arrays have padded data that is also padded. This is to test this
 struct PaddedPadded <: LayoutVector{Int} end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,10 @@ downstream_test = "--downstream_integration_test" in ARGS
         stale_deps=!downstream_test)
 end
 
+# this should only be included once to avoid method overwritten warnings, as this commites type-piracy
+# we include this at the top-level, so that other sub-modules may reuse the module instead of having to include the file
+include("infinitearrays.jl")
+
 @testset "Lazy MemoryLayout" begin
     @testset "ApplyArray" begin
         A = [1.0 2; 3 4]


### PR DESCRIPTION
Since this commits type-piracy, we should only include it once to avoid the method overwritten warnings in tests.