### PR TITLE
Only Vcats of AbstractRange can be guaranteed to be vcat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LazyArrays"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "2.3"
+version = "2.3.1"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/ext/LazyArraysBandedMatricesExt.jl
+++ b/ext/LazyArraysBandedMatricesExt.jl
@@ -311,8 +311,8 @@ _broadcast_BandedMatrix(a) = a
 for op in (:+, :-, :*)
     @eval begin
         @inline _BandedMatrix(::BroadcastBandedLayout{typeof($op)}, V::AbstractMatrix)::BandedMatrix = broadcast($op, map(_broadcast_BandedMatrix,arguments(V))...)
-        copyto!_layout(::AbstractBandedLayout, ::BroadcastBandedLayout{typeof($op)}, dest::AbstractMatrix, src::AbstractMatrix) =
-            broadcast!($op, dest, map(_broadcast_BandedMatrix, arguments(src))...)
+        copyto!_layout(::AbstractBandedLayout, srclay::BroadcastBandedLayout{typeof($op)}, dest::AbstractMatrix, src::AbstractMatrix) =
+            broadcast!($op, dest, map(_broadcast_BandedMatrix, arguments(srclay, src))...)
     end
 end
 
@@ -325,8 +325,8 @@ _mulbanded_BandedMatrix(A, _) = A
 _mulbanded_BandedMatrix(A, ::NTuple{2,OneTo{Int}}) = BandedMatrix(A)
 _mulbanded_BandedMatrix(A) = _mulbanded_BandedMatrix(A, axes(A))
 
-copyto!_layout(::AbstractBandedLayout, ::ApplyBandedLayout{typeof(*)}, dest::AbstractMatrix, src::AbstractMatrix) =
-    _mulbanded_copyto!(dest, map(_mulbanded_BandedMatrix,arguments(src))...)
+copyto!_layout(::AbstractBandedLayout, srclay::ApplyBandedLayout{typeof(*)}, dest::AbstractMatrix, src::AbstractMatrix) =
+    _mulbanded_copyto!(dest, map(_mulbanded_BandedMatrix,arguments(srclay,src))...)
 
 arguments(::BroadcastBandedLayout{F}, V::SubArray) where F = _broadcast_sub_arguments(V)
 

--- a/src/lazyconcat.jl
+++ b/src/lazyconcat.jl
@@ -786,10 +786,10 @@ end
 # subarrays
 ###
 
-sublayout(::ApplyLayout{typeof(vcat)}, ::Type{<:Tuple{Vararg{Union{AbstractVector{Int},Int}}}}) = ApplyLayout{typeof(vcat)}()
-sublayout(::ApplyLayout{typeof(hcat)}, ::Type{<:Tuple{Vararg{Union{AbstractVector{Int},Int}}}}) = ApplyLayout{typeof(hcat)}()
+sublayout(::ApplyLayout{typeof(vcat)}, ::Type{<:Tuple{Vararg{Union{AbstractUnitRange{Int},Int}}}}) = ApplyLayout{typeof(vcat)}()
+sublayout(::ApplyLayout{typeof(hcat)}, ::Type{<:Tuple{Vararg{Union{AbstractUnitRange{Int},Int}}}}) = ApplyLayout{typeof(hcat)}()
 # a row-slice of an Hcat is equivalent to a Vcat
-sublayout(::ApplyLayout{typeof(hcat)}, ::Type{<:Tuple{Int,AbstractVector{Int}}}) = ApplyLayout{typeof(vcat)}()
+sublayout(::ApplyLayout{typeof(hcat)}, ::Type{<:Tuple{Int,AbstractUnitRange{Int}}}) = ApplyLayout{typeof(vcat)}()
 
 _vcat_lastinds(sz) = _vcat_cumsum(sz...)
 _vcat_firstinds(sz) = (1, (1 .+ Base.front(_vcat_lastinds(sz)))...)
@@ -867,11 +867,11 @@ arguments(::ApplyLayout{typeof(vcat)}, V::SubArray{<:Any,2,<:Any,<:Tuple{<:Slice
 arguments(::ApplyLayout{typeof(hcat)}, V::SubArray{<:Any,2,<:Any,<:Tuple{<:Any,<:Slice}}) =
     __view_hcat(arguments(parent(V)), parentindices(V)[1], :)
 
-function sub_materialize(::ApplyLayout{typeof(vcat)}, V::AbstractMatrix, _)
+function sub_materialize(lay::ApplyLayout{typeof(vcat)}, V::AbstractMatrix, _)
     ret = similar(V)
     n = 0
     _,jr = parentindices(V)
-    for a in arguments(V)
+    for a in arguments(lay, V)
         m = size(a,1)
         copyto!(view(ret,n+1:n+m,:), a)
         n += m

--- a/test/concattests.jl
+++ b/test/concattests.jl
@@ -652,6 +652,11 @@ import LazyArrays: MemoryLayout, DenseColumnMajor, materialize!, call, paddeddat
         @test Array(Hcat()) == Array{Any}(undef,0,0)
         @test rowsupport(Hcat(Vcat(Zeros(3,1))),1:2) == colsupport(Vcat(Hcat(Zeros(1,3))),1:2)
     end
+
+    @testset "reverse Vcat" begin
+        A = Vcat([1 2 3], [4 5 6])
+        @test A[2:-1:1,1:-1:1] == [4; 1 ;;]
+    end
 end
 
 end # module


### PR DESCRIPTION
@marcusdavidwebb believe it or not, this caused the weird bug yesterday where the -Laplacian was not SPD