### PR TITLE
Explicitly import `ArrayLayouts.MemoryLayout`

### DIFF
--- a/src/LazyArrays.jl
+++ b/src/LazyArrays.jl
@@ -5,7 +5,6 @@ module LazyArrays
 
 using Base.Broadcast, LinearAlgebra, FillArrays, ArrayLayouts, SparseArrays
 import LinearAlgebra.BLAS
-import ArrayLayouts.MemoryLayout
 
 import Base: *, +, -, /, <, ==, >, \, ≤, ≥, (:), @_gc_preserve_begin, @_gc_preserve_end, @propagate_inbounds,
              AbstractArray, AbstractMatrix, AbstractVector, BroadcastStyle, IndexLinear, IndexStyle, OneTo, Slice,
@@ -40,7 +39,7 @@ import ArrayLayouts: AbstractQLayout, Dot, Dotu, Ldiv, Lmul, MatMulMatAdd, MatMu
                      materialize!, mulreduce, reshapedlayout, rowsupport, scalarone, scalarzero, sub_materialize,
                      sublayout, symmetriclayout, symtridiagonallayout, transposelayout, triangulardata,
                      triangularlayout, tridiagonallayout, zero!, transtype, OnesLayout,
-                     diagonaldata, subdiagonaldata, supdiagonaldata
+                     diagonaldata, subdiagonaldata, supdiagonaldata, MemoryLayout
 
 import FillArrays: AbstractFill, getindex_value
 

--- a/src/LazyArrays.jl
+++ b/src/LazyArrays.jl
@@ -5,6 +5,7 @@ module LazyArrays
 
 using Base.Broadcast, LinearAlgebra, FillArrays, ArrayLayouts, SparseArrays
 import LinearAlgebra.BLAS
+import ArrayLayouts.MemoryLayout
 
 import Base: *, +, -, /, <, ==, >, \, ≤, ≥, (:), @_gc_preserve_begin, @_gc_preserve_end, @propagate_inbounds,
              AbstractArray, AbstractMatrix, AbstractVector, BroadcastStyle, IndexLinear, IndexStyle, OneTo, Slice,


### PR DESCRIPTION
Prevent name ambiguity, adapt to changes in nightly Julia, preventing a warning during precompilation.

See:
* https://github.com/JuliaLang/julia/issues/25744
* https://github.com/JuliaLang/julia/issues/57290
* https://github.com/JuliaLang/julia/pull/57311