### PR TITLE
add PaddedVector and PaddedMatrix constructors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LazyArrays"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "2.6.1"
+version = "2.6.2"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/padded.jl
+++ b/src/padded.jl
@@ -591,7 +591,8 @@ PaddedArray(A::AbstractArray{T,N}, n::Vararg{Integer,N}) where {T,N} = PaddedArr
 PaddedArray(A::AbstractArray{T,N}, ax::NTuple{N,Any}) where {T,N} = ApplyArray{T,N}(setindex, Zeros{T,N}(ax), A, axes(A)...)
 PaddedArray(A::T, n::Vararg{Integer,N}) where {T<:Number,N} = ApplyArray{T,N}(setindex, Zeros{T,N}(n...), A, ntuple(_ -> OneTo(1),N)...)
 (PaddedArray{T,N} where T)(A, n::Vararg{Integer,N}) where N = PaddedArray(A, n...)
-
+PaddedVector(A::AbstractVector{T}, ax::AbstractUnitRange) where T = ApplyArray{T, 1}(setindex, Zeros{T, 1}((ax, )), A, axes(A)...)
+PaddedMatrix(A::AbstractMatrix{T}, ax::NTuple{2, Any}) where T = PaddedArray(A, ax)
 
 BroadcastStyle(::Type{<:PaddedArray{<:Any,N}}) where N = LazyArrayStyle{N}()
 

--- a/test/paddedtests.jl
+++ b/test/paddedtests.jl
@@ -325,6 +325,8 @@ paddeddata(a::PaddedPadded) = a
 
         @test PaddedArray(1, 3) == PaddedVector(1,3) == [1; zeros(2)]
         @test PaddedArray(1, 3, 3) == PaddedMatrix(1, 3, 3) == [1 zeros(1,2); zeros(2,3)]
+        @test PaddedVector([1, 2, 3], 3:5)[3:5] == [3; 0; 0]
+        @test PaddedMatrix([1 2; 3 4], (1:3, 1:3)) == [1 2 0; 3 4 0; 0 0 0]
     end
 
     @testset "adjtrans" begin


### PR DESCRIPTION
This allows creating PaddedVectors and PaddedMatrices with AbstractUnitRanges to describe their axes. Ex:
```julia
julia> using LazyArrays

julia> PaddedVector([1, 2, 3], 1:5)
setindex(5-element FillArrays.Zeros{Int64, 1, Tuple{UnitRange{Int64}}} with indices 1:5, 3-element Vector{Int64}, 3-element Base.OneTo{Int64}) with indices 1:5:
 1
 2
 3
 ⋅
 ⋅

```

Can be combined with BlockArrays to create Padded block vectors:
```julia
julia> using BlockArrays

julia> PaddedVector([1, 2, 3], blockedrange(1:3))
setindex(6-element FillArrays.Zeros{Int64, 1, Tuple{BlockedOneTo{Int64, ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}}} with indices BlockedOneTo(ArrayLayouts.RangeCumsum(1:3)), 3-element Vector{Int64}, 3-element Base.OneTo{Int64}) with indices BlockedOneTo(ArrayLayouts.RangeCumsum(1:3)):
 1
 ─
 2
 3
 ─
 ⋅
 ⋅
 ⋅

```