### PR TITLE
Preliminary support for qr with padded matrices

### DIFF
--- a/src/LazyArrays.jl
+++ b/src/LazyArrays.jl
@@ -39,7 +39,8 @@ import ArrayLayouts: AbstractQLayout, Dot, Dotu, Ldiv, Lmul, MatMulMatAdd, MatMu
                      materialize!, mulreduce, reshapedlayout, rowsupport, scalarone, scalarzero, sub_materialize,
                      sublayout, symmetriclayout, symtridiagonallayout, transposelayout, triangulardata,
                      triangularlayout, tridiagonallayout, zero!, transtype, OnesLayout,
-                     diagonaldata, subdiagonaldata, supdiagonaldata, MemoryLayout
+                     diagonaldata, subdiagonaldata, supdiagonaldata, MemoryLayout, MatLmulVec, MatLmulMat,
+                     AdjQRCompactWYQLayout
 
 import FillArrays: AbstractFill, getindex_value
 

--- a/test/paddedtests.jl
+++ b/test/paddedtests.jl
@@ -439,5 +439,15 @@ paddeddata(a::PaddedPadded) = a
         @test B*p == Matrix(B)*p
         @test simplifiable(*,B,p) == Val(true)
     end
+
+    @testset "QR" begin
+        A = Vcat(randn(5,5), Zeros(4,5))
+        F = qr!(copy(A))
+        F̃ = qr!(Matrix(A))
+        @test F.R ≈ F̃.R
+        b = Vcat([1,2], Zeros(7))
+        @test F.Q'b ≈ F̃.Q'b
+        @test ldiv!(F,cache(b)) ≈ ldiv!(F̃,Vector(b))
+    end
 end
 end # module


### PR DESCRIPTION
This is to support the ∞-dimensional case, which can be used to orthogonalise functions