### PR TITLE
Remove empty vcat show method

### DIFF
--- a/test/concattests.jl
+++ b/test/concattests.jl
@@ -643,7 +643,7 @@ import LazyArrays: MemoryLayout, DenseColumnMajor, materialize!, call, paddeddat
     @testset "empty vcat" begin
         v = ApplyArray(vcat)
         @test v isa AbstractVector{Any}
-        @test stringmime("text/plain", v) == "vcat()"
+        # @test stringmime("text/plain", v) == "vcat()"
     end
 
     @testset "matrix indexing" begin


### PR DESCRIPTION
Currently, we have 
```julia
julia> v = ApplyArray(vcat)
vcat()
```
but `vcat()` isn't the correct way to represent this object, as the call produces an empty `Vector{Any}`. It'll be better to print an actual constructor here. I'm disabling this test for now until a better representation is added.