### PR TITLE
Support sortedunion for eg Vcat(1, 3:10)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LazyArrays"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "2.11.0"
+version = "2.12.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/ext/LazyArraysBlockArraysExt.jl
+++ b/ext/LazyArraysBlockArraysExt.jl
@@ -277,7 +277,7 @@ broadcast_deblock(op, A::BlockedArray, B::BlockedArray) = broadcast(op, A.blocks
 #     __view_hcat(_reverse_if_neg_step(args, JR), kr, _reverse_if_neg_step(sJR2, JR))
 # end
 
-function sortedunion(A::Vcat{Int,1,<:Tuple{Int,AbstractVector{Int}}}, B::Vcat{Int,1,<:Tuple{Int,AbstractVector{Int}}})
+function _sortedunion_int_vcat(A, B)
     a,b = A.args
     c,d = B.args
     r = sortedunion(b, d)
@@ -294,6 +294,11 @@ function sortedunion(A::Vcat{Int,1,<:Tuple{Int,AbstractVector{Int}}}, B::Vcat{In
         Vcat(min(a,c), max(a,c), r)
     end
 end
+
+sortedunion(A::Vcat{Int,1,<:Tuple{Int,AbstractVector{Int}}}, B::Vcat{Int,1,<:Tuple{Int,AbstractVector{Int}}}) = _sortedunion_int_vcat(A, B)
+
+# needed temporarily to avoid ambiguity from type piracy.
+sortedunion(A::Vcat{Int,1,<:Tuple{Int,AbstractRange{Int}}}, B::Vcat{Int,1,<:Tuple{Int,AbstractRange{Int}}}) = _sortedunion_int_vcat(A, B)
 
 function sortedunion(A::Vcat{Int,1,<:Tuple{Int,AbstractVector{Int}}}, B::AbstractVector{Int})
     a,b = A.args

--- a/ext/LazyArraysBlockArraysExt.jl
+++ b/ext/LazyArraysBlockArraysExt.jl
@@ -11,7 +11,7 @@ import LazyArrays: resizedata!, paddeddata, paddeddata_axes, arguments, call,
                     ApplyLayout, cache_layout, applied_eltype, applylayout, applied_ndims, broadcast_deblock
 import ArrayLayouts: sub_materialize
 import Base: getindex, setindex!, BroadcastStyle, broadcasted, OneTo, axes, size, view, resize!
-import BlockArrays: AbstractBlockStyle, AbstractBlockedUnitRange, blockcolsupport, blockrowsupport, BlockSlice, BlockIndexRange, AbstractBlockLayout, blockvec
+import BlockArrays: AbstractBlockStyle, AbstractBlockedUnitRange, blockcolsupport, blockrowsupport, BlockSlice, BlockIndexRange, AbstractBlockLayout, blockvec, sortedunion
 
 BlockArrays._broadcaststyle(S::AbstractLazyArrayStyle{1}) = S
 
@@ -277,6 +277,35 @@ broadcast_deblock(op, A::BlockedArray, B::BlockedArray) = broadcast(op, A.blocks
 #     __view_hcat(_reverse_if_neg_step(args, JR), kr, _reverse_if_neg_step(sJR2, JR))
 # end
 
+function sortedunion(A::Vcat{Int,1,<:Tuple{Int,AbstractVector{Int}}}, B::Vcat{Int,1,<:Tuple{Int,AbstractVector{Int}}})
+    a,b = A.args
+    c,d = B.args
+    r = sortedunion(b, d)
+
+    # following not possible since A and B are assumed to be sorted
+    # if a ∈ r && c ∈ r
+    #     r
+    # else
+    if a ∈ r || a == c
+        Vcat(c, r)
+    elseif c ∈ r
+        Vcat(a, r)
+    else
+        Vcat(min(a,c), max(a,c), r)
+    end
+end
+
+function sortedunion(A::Vcat{Int,1,<:Tuple{Int,AbstractVector{Int}}}, B::AbstractVector{Int})
+    a,b = A.args
+    r = sortedunion(b, B)
+    if a ∈ r
+        r
+    else
+        Vcat(a, r)
+    end
+end
+
+sortedunion(B::AbstractVector{Int}, A::Vcat{Int,1,<:Tuple{Int,AbstractVector{Int}}}) = sortedunion(A, B)
 
 end
 

--- a/test/blocktests.jl
+++ b/test/blocktests.jl
@@ -199,5 +199,14 @@ struct TestLazyStyle{N} <: LazyArrays.AbstractLazyArrayStyle{N} end
         V = view(H,1:2,Block.(1:2))
         @test rowsupport(V)  == 1:5
     end
+
+    @testset "sortedunion vcat" begin
+        A = Vcat(1, 3:10)
+        B = Vcat(2, 4:10)
+        @test BlockArrays.sortedunion(A, 4:12) ≡ BlockArrays.sortedunion(4:12, A) ≡ Vcat(1,3:12)
+        @test BlockArrays.sortedunion(A, 1:12) ≡ BlockArrays.sortedunion(1:12, A) ≡ 1:12
+        @test BlockArrays.sortedunion(A, B) ≡ BlockArrays.sortedunion(B, A) ≡ Vcat(1, 2, 3:10)
+        @test BlockArrays.sortedunion(A, A) ≡ A
+    end
 end
 end

--- a/test/blocktests.jl
+++ b/test/blocktests.jl
@@ -207,6 +207,12 @@ struct TestLazyStyle{N} <: LazyArrays.AbstractLazyArrayStyle{N} end
         @test BlockArrays.sortedunion(A, 1:12) ≡ BlockArrays.sortedunion(1:12, A) ≡ 1:12
         @test BlockArrays.sortedunion(A, B) ≡ BlockArrays.sortedunion(B, A) ≡ Vcat(1, 2, 3:10)
         @test BlockArrays.sortedunion(A, A) ≡ A
+        # c ∈ r branch: c=4 is inside sortedunion(3:10, 6:10)=3:10
+        @test BlockArrays.sortedunion(A, Vcat(4, 6:10)) ≡ Vcat(1, 3:10)
+        # AbstractVector (non-range) dispatch
+        C = Vcat(1, collect(3:10))
+        D = Vcat(2, collect(4:10))
+        @test BlockArrays.sortedunion(C, D) == Vcat(1, 2, collect(3:10))
     end
 end
 end


### PR DESCRIPTION
This works around an issue with infinite block vectors downstream